### PR TITLE
remove encoded prompt because it is causing failed to publish message…

### DIFF
--- a/src/db_services/ConfigurationServices.py
+++ b/src/db_services/ConfigurationServices.py
@@ -162,7 +162,7 @@ async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None)
         pipeline = [
             # Stage 0: Match the specific bridge or version with the given org_id
             {
-                '$match': {'_id': id_to_use, "org_id": org_id}
+                '$match': {'_id': ObjectId(id_to_use), "org_id": org_id}
             },
             {
                 '$project': {


### PR DESCRIPTION
… in case of tiptapremove encoded prompt because it is causing failed to publish message…