### PR TITLE
refactor: centralize GCP file upload logic into dedicated service module

### DIFF
--- a/src/controllers/image_process_controller.py
+++ b/src/controllers/image_process_controller.py
@@ -12,13 +12,12 @@ async def image_processing(request):
     
     try:
         # Upload file using common GCP upload function
-        filename = f"{uuid.uuid4()}_{file.filename}"
         image_url = await uploadDoc(
             file=file_content,
             folder='uploads',
             real_time=True,
-            filename=filename,
-            content_type=file.content_type
+            content_type=file.content_type,
+            original_filename=file.filename
         )
         
         return {
@@ -48,13 +47,12 @@ async def file_processing(request):
         is_pdf = file.content_type == 'application/pdf' or file.filename.lower().endswith('.pdf')
         
         # Upload file using common GCP upload function
-        filename = f"{uuid.uuid4()}_{file.filename}"
         file_url = await uploadDoc(
             file=file_content,
             folder='uploads',
             real_time=True,
-            filename=filename,
-            content_type=file.content_type
+            content_type=file.content_type,
+            original_filename=file.filename
         )
 
         # If PDF and thread parameters exist, save to Redis cache

--- a/src/services/commonServices/Google/gemini_image_model.py
+++ b/src/services/commonServices/Google/gemini_image_model.py
@@ -43,12 +43,10 @@ async def gemini_image_model(configuration, apikey, execution_time_logs, timer):
                 img_buffer.seek(0)
                 
                 # Upload to GCP using common upload function
-                filename = f"{uuid.uuid4()}.png"
                 gcp_url = await uploadDoc(
                     file=img_buffer,
                     folder='generated-images',
                     real_time=True,
-                    filename=filename,
                     content_type='image/png'
                 )
                 

--- a/src/services/commonServices/openAI/image_model.py
+++ b/src/services/commonServices/openAI/image_model.py
@@ -20,12 +20,10 @@ async def OpenAIImageModel(configuration, apiKey, execution_time_logs, timer):
             original_image_url = image_data['url']
             
             # Generate predictable GCP URL immediately and start background upload
-            filename = f"{uuid.uuid4()}.png"
             gcp_url = await uploadDoc(
                 file=original_image_url,
                 folder='generated-images',
                 real_time=False,
-                filename=filename,
                 content_type='image/png'
             )
             


### PR DESCRIPTION
This PR centralizes GCP file upload functionality by creating a dedicated service module.

## Changes:
- **Created new service**: `src/services/utils/gcp_upload_service.py`
  - Unified `uploadDoc()` function that handles different file types (bytes, URLs, file objects)
  - Supports both real-time and background uploads
  - Centralized GCP credentials and bucket configuration
  - Comprehensive error handling

- **Refactored image processing controllers**:
  - `src/controllers/image_process_controller.py`: Removed duplicated GCP setup code
  - `src/services/commonServices/Google/gemini_image_model.py`: Simplified upload logic
  - `src/services/commonServices/openAI/image_model.py`: Removed background upload function

## Benefits:
- **DRY Principle**: Eliminated code duplication across multiple files
- **Maintainability**: Single source of truth for GCP upload logic
- **Consistency**: Unified error handling and configuration management
- **Flexibility**: Support for various upload scenarios (real-time vs background)

## Testing:
- Verified image upload functionality works correctly
- Background upload tasks execute as expected
- Error handling provides appropriate feedback