### PR TITLE
api key version update bug fix

### DIFF
--- a/src/db_services/ConfigurationServices.py
+++ b/src/db_services/ConfigurationServices.py
@@ -730,6 +730,13 @@ async def update_apikey_creds(version_id, apikey_object_ids):
     try:
         if isinstance(apikey_object_ids, dict):
             for service, api_key_id in apikey_object_ids.items():
+                # First, remove the version_id from any apikeycredentials documents that contain it
+                await apikeyCredentialsModel.update_many(
+                    {'version_ids': version_id},
+                    {'$pull': {'version_ids': version_id}}
+                )
+                
+                # Then add the version_id to the target document
                 await apikeyCredentialsModel.update_one(
                     {'_id': ObjectId(api_key_id)},
                     {'$addToSet': {'version_ids': version_id}},


### PR DESCRIPTION
Bug fix: The version id from the API key credentials of previous API key does not get deleted when updating the API key.