### PR TITLE
refactor: consolidate configuration settings under settings object

### DIFF
--- a/src/middlewares/interfaceMiddlewares.py
+++ b/src/middlewares/interfaceMiddlewares.py
@@ -69,11 +69,11 @@ async def send_data_middleware(request: Request, botId: str, body: ChatbotSendMe
                 **body.variables,
                 **json.loads(profile.get("variables", "{}")),
             },
-            "configuration": {
+            "settings": {
                 "response_format": {"type": "default", "cred": {}}
                 if flag
                 else {"type": "RTLayer", "cred": {"channel": channelId, "ttl": 1, "apikey": Config.RTLAYER_AUTH}},
-                **body.configuration,
+                **body.configuration.get("settings", {}),
                 "max_token": bridges.get("max_token", None) if isPublic else None,
             },
             "chatbot": True,

--- a/src/routes/v2/modelRouter.py
+++ b/src/routes/v2/modelRouter.py
@@ -81,7 +81,7 @@ async def playground_chat_completion_bridge(
     flag = data_to_send.get("body", {}).get("flag") or False
     if not flag:
         response_format = {"type": "RTLayer", "cred": {"channel": channel_id, "ttl": 1, "apikey": Config.RTLAYER_AUTH}}
-        data_to_send["body"]["configuration"]["response_format"] = response_format
+        data_to_send["body"]["settings"]["response_format"] = response_format
     # Check if response_format is present and publish to queue
     if not flag and response_format and response_format.get("type") != "default":
         try:

--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -104,7 +104,7 @@ async def chat_multiple_agents(request_body):
         # Save request-level values from "configuration" that must survive the
         # bridge-config merge (primary_config["configuration"] is the raw DB config
         # and will fully overwrite primary_body["configuration"] via .update()).
-        original_response_format = (body.get("configuration") or {}).get("response_format")
+        original_response_format = (body.get("settings") or {}).get("response_format")
 
         primary_body.update(primary_config)
         primary_body["wrapper_id"] = wrapper_id

--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -597,7 +597,6 @@ def build_service_params(
         "modelOutputConfig": model_output_config,
         "playground": parsed_data["is_playground"],
         "template": parsed_data["template"],
-        "response_format": parsed_data["response_format"],
         "execution_time_logs": parsed_data.get("execution_time_logs", []),
         "function_time_logs": [],
         "timer": timer,

--- a/src/services/utils/getConfiguration.py
+++ b/src/services/utils/getConfiguration.py
@@ -146,6 +146,7 @@ async def _prepare_configuration_response(
             "apikey": apikey,
             "apikey_object_id": apikey_object_id,
             "RTLayer": False,
+            "settings": result.get("bridges", {}).get("settings", {}),
             "bridge_id": result["bridges"].get("parent_id", result["bridges"].get("_id")),
             "version_id": version_id or result.get("bridges", {}).get("published_version_id"),
         }

--- a/src/services/utils/helper.py
+++ b/src/services/utils/helper.py
@@ -227,7 +227,7 @@ class Helper:
             ]:
                 if key == "response_format":
                     config[key] = db_config.get(
-                        key, response["configuration"].get(key, {"type": "default", "cred": {}})
+                        key, response["settings"].get(key, {"type": "default", "cred": {}})
                     )
                 elif key == "fine_tune_model":
                     config[key] = db_config.get(key, response["configuration"].get(key, {}))


### PR DESCRIPTION
- Moved response_format from configuration to settings in interfaceMiddlewares.py
- Updated modelRouter.py to access response_format from settings instead of configuration
- Changed common.py to retrieve original_response_format from settings object
- Removed response_format from build_service_params in common_utils.py
- Added settings object to configuration response in getConfiguration.py
- Updated helper.py to access response