### PR TITLE
refactor: move response_format from configuration to settings in mode…

### DIFF
--- a/src/routes/v2/modelRouter.py
+++ b/src/routes/v2/modelRouter.py
@@ -35,6 +35,10 @@ async def chat_completion(request: Request, db_config: dict = Depends(add_config
 
     message_id = str(uuid.uuid1())
     data_to_send["body"]["message_id"] = message_id
+
+    if data_to_send['body']['configuration'].get('response_format') is not None:
+        data_to_send['body']['settings']['response_format'] = data_to_send['body']['configuration']['response_format']
+        del data_to_send['body']['configuration']['response_format']
     
     response_format = data_to_send.get("body", {}).get("settings", {}).get("response_format",{}) 
     mode = data_to_send.get("body", {}).get("mode")

--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -115,7 +115,7 @@ async def chat_multiple_agents(request_body):
         # Restore response_format set at request-level (e.g. RTLayer from playground/
         # interface middleware) that was clobbered by the bridge-config merge above.
         if original_response_format is not None:
-            primary_body.setdefault("configuration", {})["response_format"] = original_response_format
+            primary_body.setdefault("settings", {})["response_format"] = original_response_format
             print(f"[chat_multiple_agents] response_format restored: type={original_response_format.get('type')}, channel={original_response_format.get('cred', {}).get('channel')}")
 
         # Create a complete request_body structure for the primary agent

--- a/src/services/utils/helper.py
+++ b/src/services/utils/helper.py
@@ -565,7 +565,7 @@ def build_rerun_queue_message(log, data_to_send):
         "user_urls": log.get("user_urls") or [],
         "is_rerun": True,
     })
-    body.setdefault("configuration", {}).update({"response_format": {"type": "default"}, "stream": False})
+    body.setdefault("settings", {}).update({"response_format": {"type": "default"}, "stream": False})
     return {"body": body, "state": data_to_send.get("state", {}), "path_params": data_to_send.get("path_params", {})}
 
 


### PR DESCRIPTION
…lRouter and related services

- Added migration logic in modelRouter.py to move response_format from configuration to settings
- Updated common.py to restore response_format under settings instead of configuration
- Changed helper.py to set response_format under settings in build_rerun_queue_message