### PR TITLE
fix: preserve incoming response_format in bridge requests and ensure …

### DIFF
--- a/src/middlewares/getDataUsingBridgeId.py
+++ b/src/middlewares/getDataUsingBridgeId.py
@@ -74,9 +74,12 @@ async def add_configuration_data_to_body(request: Request):
                     request.state.profile["owner_id"] = f"{org_id}_{bridge_folder_id}_{bridge_user_id}"
 
         body_wrapper_id = body.get("wrapper_id")
+        incoming_response_format = body.get("settings", {}).get("response_format")
         body.update(primary_config)
         if body_wrapper_id is not None:
             body["wrapper_id"] = body_wrapper_id
+        if incoming_response_format is not None:
+            body.setdefault("settings", {})["response_format"] = incoming_response_format
         
         explicit_stream = body.get("stream")
 

--- a/src/middlewares/interfaceMiddlewares.py
+++ b/src/middlewares/interfaceMiddlewares.py
@@ -70,10 +70,10 @@ async def send_data_middleware(request: Request, botId: str, body: ChatbotSendMe
                 **json.loads(profile.get("variables", "{}")),
             },
             "settings": {
+                **body.configuration.get("settings", {}),
                 "response_format": {"type": "default", "cred": {}}
                 if flag
                 else {"type": "RTLayer", "cred": {"channel": channelId, "ttl": 1, "apikey": Config.RTLAYER_AUTH}},
-                **body.configuration.get("settings", {}),
                 "max_token": bridges.get("max_token", None) if isPublic else None,
             },
             "chatbot": True,

--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -431,7 +431,7 @@ async def chat(request_body):
                 parsed_data["model"] = original_model
                 parsed_data["service"] = original_service
                 parsed_data["firstAttemptError"] = (
-                        f"Original attempt failed with {original_service}/{original_model}: {original_error}. Retried with {parsed_data['service']}/{parsed_data['model']}"
+                        f"Original attempt failed with {original_service}/{original_model}: {original_error}. Retried with {fallback_config['service']}/{fallback_config['model']}"
                     )
                 raise retry_error from original_exception
 

--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -597,6 +597,7 @@ def build_service_params(
         "modelOutputConfig": model_output_config,
         "playground": parsed_data["is_playground"],
         "template": parsed_data["template"],
+        "response_format": parsed_data.get("response_format") or {},
         "execution_time_logs": parsed_data.get("execution_time_logs", []),
         "function_time_logs": [],
         "timer": timer,


### PR DESCRIPTION
…proper initialization order

- Store incoming response_format from request body before updating with primary_config in getDataUsingBridgeId
- Restore incoming response_format after config merge to prevent override
- Reorder settings initialization in interfaceMiddlewares to apply configuration settings before default response_format
- Add response_format fallback with empty dict in build_service_params to prevent None values