### PR TITLE
refactor: always rebuild service handler during fallback to prevent s…

### DIFF
--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -360,56 +360,45 @@ async def chat(request_body):
                 original_model = parsed_data["model"]
 
                 # Update parsed_data with fallback configuration
-                parsed_data["model"] = fallback_config.get("model", parsed_data["model"])
-                parsed_data["service"] = fallback_config.get("service", parsed_data["service"])
-                parsed_data["configuration"]["model"] = fallback_config.get("model")
-                # Check if service has changed - if so, create new service handler
-                if parsed_data["service"] != original_service:
-                    parsed_data["apikey"] = fallback_config.get("apikey")
+                fallback_model = fallback_config.get("model", parsed_data["model"])
+                fallback_service = fallback_config.get("service", parsed_data["service"])
+                parsed_data["model"] = fallback_model
+                parsed_data["service"] = fallback_service
+                parsed_data["configuration"]["model"] = fallback_model
+                if fallback_config.get("apikey"):
+                    parsed_data["apikey"] = fallback_config["apikey"]
 
-                    # Load fresh model configuration for the fallback service and model
-                    (
-                        fallback_model_config,
-                        fallback_custom_config,
-                        fallback_model_output_config,
-                    ) = await load_model_configuration(
-                        parsed_data["model"], parsed_data["configuration"], parsed_data["service"]
+                # Always rebuild fallback handler/config to avoid stale customConfig/model reuse
+                (
+                    fallback_model_config,
+                    fallback_custom_config,
+                    fallback_model_output_config,
+                ) = await load_model_configuration(
+                    parsed_data["model"], parsed_data["configuration"], parsed_data["service"]
+                )
+
+                fallback_custom_config = await configure_custom_settings(
+                    fallback_model_config["configuration"], fallback_custom_config, parsed_data["service"]
+                )
+                params = build_service_params(
+                    parsed_data,
+                    fallback_custom_config,
+                    fallback_model_output_config,
+                    thread_info,
+                    timer,
+                    memory,
+                    bridge_configurations,
+                )
+
+                if (
+                    "response_type" in fallback_custom_config
+                    and fallback_custom_config["response_type"].get("type") == "json_schema"
+                ):
+                    fallback_custom_config["response_type"] = restructure_json_schema(
+                        fallback_custom_config["response_type"], parsed_data["service"]
                     )
 
-                    # Configure custom settings specifically for the fallback service
-                    fallback_custom_config = await configure_custom_settings(
-                        fallback_model_config["configuration"], fallback_custom_config, parsed_data["service"]
-                    )
-                    params = build_service_params(
-                        parsed_data,
-                        fallback_custom_config,
-                        fallback_model_output_config,
-                        thread_info,
-                        timer,
-                        memory,
-                        bridge_configurations,
-                    )
-                    # Step 9 : json_schema service conversion
-                    if (
-                        "response_type" in fallback_custom_config
-                        and fallback_custom_config["response_type"].get("type") == "json_schema"
-                    ):
-                        fallback_custom_config["response_type"] = restructure_json_schema(
-                            fallback_custom_config["response_type"], parsed_data["service"]
-                        )
-
-                    # Create new service handler for the fallback service
-                    class_obj = await Helper.create_service_handler(params, parsed_data["service"])
-                else:
-                    # Same service, just update existing class_obj
-                    class_obj.model = parsed_data["model"]
-                    if fallback_config.get("apikey"):
-                        class_obj.apikey = fallback_config["apikey"]
-
-                    # Reconfigure custom_config for fallback service
-                    class_obj.customConfig = await configure_custom_settings(
-                        model_config["configuration"], custom_config, parsed_data["service"]
-                    )
+                class_obj = await Helper.create_service_handler(params, parsed_data["service"])
 
                 # Execute with updated configuration
                 result = await class_obj.execute()

--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -1344,34 +1344,30 @@ async def sse_stream_and_finalize(class_obj, parsed_data, params, timer, thread_
 
         if fall_back and fall_back.get("is_enable", False):
             try:
-                parsed_data["model"] = fall_back.get("model", parsed_data["model"])
-                parsed_data["service"] = fall_back.get("service", parsed_data["service"])
-                parsed_data["configuration"]["model"] = fall_back.get("model")
+                fallback_model = fall_back.get("model", parsed_data["model"])
+                fallback_service = fall_back.get("service", parsed_data["service"])
+                parsed_data["model"] = fallback_model
+                parsed_data["service"] = fallback_service
+                parsed_data["configuration"]["model"] = fallback_model
+                if fall_back.get("apikey"):
+                    parsed_data["apikey"] = fall_back["apikey"]
 
-                if parsed_data["service"] != original_service:
-                    parsed_data["apikey"] = fall_back.get("apikey")
-                    fb_model_config, fb_custom_config, fb_model_output_config = await load_model_configuration(
-                        parsed_data["model"], parsed_data["configuration"], parsed_data["service"]
-                    )
-                    fb_custom_config = await configure_custom_settings(
-                        fb_model_config["configuration"], fb_custom_config, parsed_data["service"]
-                    )
-                    fallback_params = build_service_params(
-                        parsed_data,
-                        fb_custom_config,
-                        fb_model_output_config,
-                        thread_info,
-                        timer,
-                        params.get("memory"),
-                        bridge_configurations,
-                    )
-                    fallback_class_obj = await Helper.create_service_handler(fallback_params, parsed_data["service"])
-                else:
-                    fallback_class_obj = class_obj
-                    fallback_class_obj.model = parsed_data["model"]
-                    if fall_back.get("apikey"):
-                        fallback_class_obj.apikey = fall_back["apikey"]
-                    fallback_params = params
+                fb_model_config, fb_custom_config, fb_model_output_config = await load_model_configuration(
+                    parsed_data["model"], parsed_data["configuration"], parsed_data["service"]
+                )
+                fb_custom_config = await configure_custom_settings(
+                    fb_model_config["configuration"], fb_custom_config, parsed_data["service"]
+                )
+                fallback_params = build_service_params(
+                    parsed_data,
+                    fb_custom_config,
+                    fb_model_output_config,
+                    thread_info,
+                    timer,
+                    params.get("memory"),
+                    bridge_configurations,
+                )
+                fallback_class_obj = await Helper.create_service_handler(fallback_params, parsed_data["service"])
 
                 # Transfer the live streamer so the same SSE queue/RTLayer channel is reused
                 fallback_class_obj.streamer = class_obj.streamer


### PR DESCRIPTION
…tale config reuse

- Removed conditional logic that reused existing class_obj when service didn't change
- Now always calls load_model_configuration and create_service_handler for fallback
- Ensures fresh customConfig and model configuration on every fallback attempt
- Applied same pattern in both chat() and sse_stream_and_finalize() functions