### PR TITLE
Refactor template rendering to support streaming with dedicated templ…

### DIFF
--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -10,7 +10,6 @@ from config import Config
 from globals import TRANSFER_HISTORY, BadRequestException, logger
 from models.mongo_connection import db
 from src.configs.constant import redis_keys, alert_types
-from src.utils.formatter import apply_variables_to_template_json, fix_json_string
 from src.handler.executionHandler import handle_exceptions
 from src.services.cache_service import find_in_cache, store_in_cache
 from src.services.utils.common_utils import (
@@ -43,6 +42,7 @@ from src.services.utils.common_utils import (
     process_batch_background_tasks,
     update_cost_usage_and_apikey_status_in_background,
     sse_stream_and_finalize,
+    render_template_if_applicable,
 )
 from src.services.utils.guardrails_validator import guardrails_check
 from src.services.utils.rich_text_support import process_chatbot_response
@@ -235,11 +235,12 @@ async def chat(request_body):
         custom_config = await configure_custom_settings(
             model_config["configuration"], custom_config, parsed_data["service"]
         )
-        # If template rendering is requested, streaming is not supported — force it off
         response_type = parsed_data.get("response_type") or {}
-        if isinstance(response_type, dict) and response_type.get("is_template", False):
-            if custom_config.get("stream", False):
-                custom_config["stream"] = False
+        template_requested = isinstance(response_type, dict) and response_type.get("is_template", False)
+        if template_requested:
+            parsed_data.setdefault("flags", {})["template_requested"] = True
+            # When templates are requested we still allow streaming, but emit a dedicated
+            # template_response event (handled inside sse_stream_and_finalize).
 
         # Step 9: Execute Service Handler
         params = build_service_params(
@@ -474,72 +475,7 @@ async def chat(request_body):
             result["response"]["usage"]["cost"] = parsed_data["tokens"].get("total_cost") or 0
 
         # Template HTML Generation
-        response_type = parsed_data.get('response_type', {})
-        template_data = None
-        if isinstance(response_type, dict) and response_type.get('is_template', False):
-            try:
-                template_ids = response_type.get('template_id', [])
-                if not template_ids:
-                    logger.warning("Template Rendering: 'is_template' is True but 'template_id' is missing or empty.")
-                base_template = None
-                if template_ids and response_type:
-                    # Get templates from parsed_data (already fetched in pipeline)
-                    richui_templates = parsed_data.get('richui_templates', {})
-
-                    # AI Result Data
-                    ai_data = result.get('response', {}).get('data', {}).get('content', {})
-                    # Unwrap 'item' if present
-                    if isinstance(ai_data, dict) and "item" in ai_data:
-                        ai_data = ai_data["item"]
-                    elif isinstance(ai_data, str):
-                        try:
-                            parsed = json.loads(ai_data)
-                            if isinstance(parsed, dict) and "item" in parsed:
-                                ai_data = parsed["item"]
-                            else:
-                                ai_data = parsed
-                        except Exception:
-                            try:
-                                repaired = fix_json_string(ai_data)
-                                ai_data = json.loads(repaired)
-                                ai_data = ai_data.get("item")
-                            except Exception:
-                                pass  # keep ai_data as the raw string
-                    
-                    # Get template directly using widget_id from ai_data
-                    if isinstance(ai_data, dict):
-                        widget_id = ai_data.get('widget_id')
-                        if widget_id and str(widget_id) in richui_templates:
-                            base_template = richui_templates[str(widget_id)]
-                        else:
-                            logger.warning(f"Template with widget_id '{widget_id}' not found in richui_templates")
-                        
-                    # Only render if we have a matching template
-                    if base_template:
-                        try:
-                            render_format = base_template.get('template_format', {})
-                            render_data = ai_data if isinstance(ai_data, dict) else {}
-                            filled_json = apply_variables_to_template_json(
-                                render_format,
-                                render_data
-                            )
-                            result['response']['type'] = 'richui_json'
-                            result['response']['data']['content'] = filled_json
-                            result['response']['data']['ai_response'] = render_data
-
-                            # Store template data for history in chatbot_message
-                            template_data = {
-                                'template_id': base_template.get('_id') or base_template.get('id'),
-                                'template_name': base_template.get('name'),
-                                'is_template': True
-                            }
-                        except Exception as render_err:
-                            logger.error(f"Template Rendering Failed: {render_err}")
-                    else:
-                        # No template found or matched, return data as-is (default behavior for greetings, etc.)
-                        logger.info("No matching template found, returning data as-is")
-            except Exception as e:
-                logger.error(f"Error rendering template: {str(e)}")
+        template_data = render_template_if_applicable(parsed_data, result)
         # Add template data to historyParams chatbot_message if template was used and not playground
         if template_data and result.get('historyParams') and not parsed_data.get("is_playground"):
             result['historyParams']['chatbot_message'] = json.dumps(result['response']['data']['content'])

--- a/src/services/commonServices/streaming_service.py
+++ b/src/services/commonServices/streaming_service.py
@@ -52,6 +52,16 @@ class StreamingService:
     async def emit_tool_result(self, name: str, content: str, call_id: str):
         await self._emit({"event": "tool_result", "name": name, "content": content, "call_id": call_id})
 
+    async def emit_template_response(self, message_id: str, content: dict, metadata: dict | None = None):
+        payload = {
+            "event": "template_response",
+            "message_id": message_id,
+            "content": content,
+        }
+        if metadata:
+            payload["metadata"] = metadata
+        await self._emit(payload)
+
     async def emit_done(self, usage: dict, message_id: str, finish_reason: str, accumulated_data: dict = None):
         payload = {
             "event": "done",

--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -26,10 +26,11 @@ from src.services.utils.apiservice import fetch
 from src.services.utils.time import Timer
 from src.services.utils.token_calculation import TokenCalculator
 from src.services.utils.update_and_check_cost import update_cost, update_last_used
+from src.utils.formatter import apply_variables_to_template_json, fix_json_string
+from src.services.utils.helper import Helper
 
 from ...controllers.conversationController import getThread
 from ..commonServices.baseService.utils import sendResponse
-from .helper import Helper
 
 UTC = timezone.utc
 
@@ -234,6 +235,76 @@ def parse_request_body(request_body):
         "limit": body.get("limit"),
         "is_rerun": body.get("is_rerun", False),
     }
+
+
+def render_template_if_applicable(parsed_data, result):
+    response_type = parsed_data.get("response_type", {})
+    template_data = None
+
+    if not (isinstance(response_type, dict) and response_type.get("is_template", False)):
+        return template_data
+
+    try:
+        template_ids = response_type.get("template_id", [])
+        if not template_ids:
+            logger.warning(
+                "Template Rendering: 'is_template' is True but 'template_id' is missing or empty."
+            )
+
+        base_template = None
+        if template_ids and response_type:
+            richui_templates = parsed_data.get("richui_templates", {}) or {}
+
+            ai_data = result.get("response", {}).get("data", {}).get("content", {})
+            if isinstance(ai_data, dict) and "item" in ai_data:
+                ai_data = ai_data["item"]
+            elif isinstance(ai_data, str):
+                try:
+                    parsed = json.loads(ai_data)
+                    if isinstance(parsed, dict) and "item" in parsed:
+                        ai_data = parsed["item"]
+                    else:
+                        ai_data = parsed
+                except Exception:
+                    try:
+                        repaired = fix_json_string(ai_data)
+                        ai_data = json.loads(repaired)
+                        ai_data = ai_data.get("item")
+                    except Exception:
+                        pass
+
+            if isinstance(ai_data, dict):
+                widget_id = ai_data.get("widget_id")
+                if widget_id and str(widget_id) in richui_templates:
+                    base_template = richui_templates[str(widget_id)]
+                else:
+                    logger.warning(
+                        f"Template with widget_id '{widget_id}' not found in richui_templates"
+                    )
+
+            if base_template:
+                try:
+                    render_format = base_template.get("template_format", {})
+                    render_data = ai_data if isinstance(ai_data, dict) else {}
+                    filled_json = apply_variables_to_template_json(render_format, render_data)
+                    result.setdefault("response", {}).setdefault("data", {})
+                    result["response"]["type"] = "richui_json"
+                    result["response"]["data"]["content"] = filled_json
+                    result["response"]["data"]["ai_response"] = render_data
+
+                    template_data = {
+                        "template_id": base_template.get("_id") or base_template.get("id"),
+                        "template_name": base_template.get("name"),
+                        "is_template": True,
+                    }
+                except Exception as render_err:
+                    logger.error(f"Template Rendering Failed: {render_err}")
+            else:
+                logger.info("No matching template found, returning data as-is")
+    except Exception as exc:
+        logger.error(f"Error rendering template: {str(exc)}")
+
+    return template_data
 
 
 async def apply_prompt_wrapper(parsed_data):
@@ -1313,6 +1384,7 @@ async def sse_stream_and_finalize(class_obj, parsed_data, params, timer, thread_
     original_model = parsed_data["model"]
     timer.start()
     original_error = None
+    template_data = None
 
     try:
         from src.services.commonServices.response_caching_service import handle_response_caching
@@ -1378,6 +1450,10 @@ async def sse_stream_and_finalize(class_obj, parsed_data, params, timer, thread_
                 await class_obj.streamer.emit_error(original_error)
                 await class_obj.streamer.close()
             return
+
+    template_data = render_template_if_applicable(parsed_data, result)
+    result.setdefault("response", {}).setdefault("data", {})
+    rendered_content = result["response"]["data"].get("content", {})
 
     # Handle agent transfer: save agent A's metrics/history, then fire agent B with the live streamer
     transfer_agent_config = result.get("transfer_agent_config") if isinstance(result, dict) else None
@@ -1448,6 +1524,16 @@ async def sse_stream_and_finalize(class_obj, parsed_data, params, timer, thread_
             result["response"]["usage"]["cost"] = parsed_data["tokens"].get("total_cost") or 0
         params["execution_time_logs"].append({"step": "streaming", "time_taken": round(timer.stop("streaming"), 4)})
         latency = create_latency_object(timer, params)
+        if template_data and result.get("historyParams") and not parsed_data.get("is_playground"):
+            result["historyParams"]["chatbot_message"] = json.dumps(rendered_content)
+
+        if template_data and class_obj.streamer:
+            await class_obj.streamer.emit_template_response(
+                message_id=str(parsed_data.get("message_id") or ""),
+                content=rendered_content,
+                metadata=template_data,
+            )
+
         if not parsed_data["is_playground"]:
             if result.get("response") and result["response"].get("data"):
                 result["response"]["data"]["message_id"] = parsed_data["message_id"]
@@ -1471,11 +1557,12 @@ async def sse_stream_and_finalize(class_obj, parsed_data, params, timer, thread_
                 or model_response.get("status")
                 or ""
             )
+            accumulated_payload = None if template_data else formatted_response
             await class_obj.streamer.emit_done(
                 usage=formatted_response.get("usage", {}),
                 message_id=str(parsed_data.get("message_id") or ""),
                 finish_reason=finish_reason,
-                accumulated_data=formatted_response,
+                accumulated_data=accumulated_payload,
             )
             await class_obj.streamer.close()
     except Exception as err:


### PR DESCRIPTION
…ate_response event

- Extracted template rendering logic from chat() into a reusable render_template_if_applicable() function in common_utils.py
- Added emit_template_response() method to StreamingService for emitting template-specific events during streaming
- Modified sse_stream_and_finalize() to render templates and emit template_response events when streaming is enabled
- Removed forced stream=False behavior when templates are requested