### PR TITLE
feat: add publish_plan_history_update function and enhance task execu…

### DIFF
--- a/src/db_services/metrics_service.py
+++ b/src/db_services/metrics_service.py
@@ -389,5 +389,37 @@ def build_orchestrator_log_data(transfer_chain, thread_info=None):
     }
 
 
+async def publish_plan_history_update(message_id, final_plan, history_params):
+    """
+    Publish an update_history message to the log queue so Node.js can update
+    an existing history entry (identified by message_id) once plan execution
+    is complete.  The initial entry was created during the planning phase with
+    the same message_id.
+
+    Args:
+        message_id: The message_id that was stored in the plan when it was created.
+        final_plan: The fully-executed plan dict with task results.
+        history_params: Dict with optional keys: message, finish_reason, status.
+    """
+    try:
+        from ..services.cache_service import make_json_serializable
+        from ..services.commonServices.queueService.queueLogService import sub_queue_obj
+
+        update_data = {
+            "message_id": str(message_id),
+            "llm_message": history_params.get("message", ""),
+            "plans": final_plan,
+            "finish_reason": history_params.get("finish_reason", "stop"),
+            "status": history_params.get("status", True),
+        }
+        message = make_json_serializable({"update_history": update_data})
+        await sub_queue_obj.publish_message(message)
+        logger.info(f"Published plan history update for message_id: {message_id}")
+
+    except Exception as error:
+        logger.error(f"Error publishing plan history update: {str(error)}")
+        logger.error(traceback.format_exc())
+
+
 # Exporting functions
-__all__ = ["find", "find_one", "find_one_pg", "create_batch_conversation_logs", "build_history_and_metrics_payload", "build_orchestrator_log_data"]
+__all__ = ["find", "find_one", "find_one_pg", "create_batch_conversation_logs", "build_history_and_metrics_payload", "build_orchestrator_log_data", "publish_plan_history_update"]

--- a/src/services/todo/executor_service.py
+++ b/src/services/todo/executor_service.py
@@ -55,6 +55,12 @@ async def _execute_single_task(task_id, task, org_id, bridge_id, thread_id, sub_
     stream are forwarded to the client in real-time, tagged with `task_id`.
     """
     assigned_agent = task.get("assigned_agent") or bridge_id
+    # A task is a "primary-agent sub-task" when no explicit agent was assigned
+    # (or the assigned agent is the main bridge itself).  For these we skip
+    # per-sub-task history so the conversation log shows only the final plan
+    # result saved by todo_handler, not every intermediate LLM call.
+    is_primary_agent_task = not task.get("assigned_agent") or task.get("assigned_agent") == bridge_id
+
     task_description = task.get("task_description", task.get("title", ""))
     human_response = task.get("human_response")
     if human_response:
@@ -75,6 +81,9 @@ async def _execute_single_task(task_id, task, org_id, bridge_id, thread_id, sub_
             "variables": {},
             "bridge_configurations": bridge_configurations,
             "plans": plan,
+            # Skip per-sub-task history for the primary agent; its final
+            # response is saved once by todo_handler after full execution.
+            "skip_history": is_primary_agent_task,
         }
         
         request_body.update(agent_config)

--- a/src/services/todo/planner_service.py
+++ b/src/services/todo/planner_service.py
@@ -266,6 +266,8 @@ async def create_plan(parsed_data, bridge_configurations, streamer):
         "thread_id": parsed_data["thread_id"],
         "sub_thread_id": parsed_data.get("sub_thread_id") or parsed_data["thread_id"],
         "tasks": plan_data.get("tasks", {}),
+        # Persisted so execution phases can update the same history entry
+        "message_id": parsed_data.get("message_id", ""),
     }
 
     await plan_store.save_plan(plan)

--- a/src/services/todo/todo_handler.py
+++ b/src/services/todo/todo_handler.py
@@ -8,6 +8,7 @@ from src.services.commonServices.streaming_service import StreamingService
 from src.services.todo import executor_service, plan_store, planner_service
 from src.controllers.conversationController import save_sub_thread_id_and_name
 from src.services.utils.common_utils import _publish_history_to_queue
+from src.db_services.metrics_service import publish_plan_history_update
 
 
 def _format_plan_response(plan, message_id, model="", finish_reason="completed", extract_final_result=False):
@@ -80,6 +81,19 @@ def _format_plan_response(plan, message_id, model="", finish_reason="completed",
     }
 
 
+def _build_plan_dataset(parsed_data):
+    """Minimal dataset dict for a plan-mode history entry (no token tracking at plan level)."""
+    return {
+        "orgId": parsed_data.get("org_id"),
+        "service": parsed_data.get("service"),
+        "model": parsed_data.get("model", ""),
+        "success": True,
+        "inputTokens": 0,
+        "outputTokens": 0,
+        "total_tokens": 0,
+    }
+
+
 async def _stream_plan_action(streamer, action, parsed_data, bridge_configurations, existing_plan):
     """Background task: execute the plan action and emit SSE events."""
     org_id = parsed_data["org_id"]
@@ -117,11 +131,25 @@ async def _stream_plan_action(streamer, action, parsed_data, bridge_configuratio
                 org_id, bridge_id, thread_id, sub_thread_id, bridge_configurations, streamer=streamer
             )
             final_plan = await plan_store.get_plan(org_id, bridge_id, thread_id, sub_thread_id)
+            formatted = _format_plan_response(final_plan, message_id, model, extract_final_result=True)
             await streamer.emit_done(
                 usage={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
                 message_id=message_id,
                 finish_reason="stop",
-                accumulated_data=_format_plan_response(final_plan, message_id, model, extract_final_result=True),
+                accumulated_data=formatted,
+            )
+            # Update the history entry that was created during planning
+            plan_message_id = (final_plan or {}).get("message_id") or message_id
+            asyncio.create_task(
+                publish_plan_history_update(
+                    message_id=plan_message_id,
+                    final_plan=final_plan,
+                    history_params={
+                        "message": formatted["data"]["content"],
+                        "finish_reason": "stop",
+                        "status": (final_plan or {}).get("state") == "completed",
+                    },
+                )
             )
 
         elif action == "status":
@@ -175,11 +203,25 @@ async def _stream_plan_action(streamer, action, parsed_data, bridge_configuratio
                 org_id, bridge_id, thread_id, sub_thread_id, bridge_configurations, streamer=streamer
             )
             final_plan = await plan_store.get_plan(org_id, bridge_id, thread_id, sub_thread_id)
+            formatted = _format_plan_response(final_plan, message_id, model, extract_final_result=True)
             await streamer.emit_done(
                 usage={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
                 message_id=message_id,
                 finish_reason="stop",
-                accumulated_data=_format_plan_response(final_plan, message_id, model, extract_final_result=True),
+                accumulated_data=formatted,
+            )
+            # Update the history entry that was created during planning
+            plan_message_id = (final_plan or {}).get("message_id") or message_id
+            asyncio.create_task(
+                publish_plan_history_update(
+                    message_id=plan_message_id,
+                    final_plan=final_plan,
+                    history_params={
+                        "message": formatted["data"]["content"],
+                        "finish_reason": "stop",
+                        "status": (final_plan or {}).get("state") == "completed",
+                    },
+                )
             )
 
         elif action == "retry":
@@ -210,18 +252,25 @@ async def _stream_plan_action(streamer, action, parsed_data, bridge_configuratio
                 org_id, bridge_id, thread_id, sub_thread_id, bridge_configurations, streamer=streamer
             )
             final_plan = await plan_store.get_plan(org_id, bridge_id, thread_id, sub_thread_id)
+            formatted = _format_plan_response(final_plan, message_id, model, extract_final_result=True)
             await streamer.emit_done(
                 usage={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
                 message_id=message_id,
                 finish_reason="stop",
-                accumulated_data=_format_plan_response(final_plan, message_id, model, extract_final_result=True),
+                accumulated_data=formatted,
             )
-            
-            # Save history with plans
-            await _publish_history_to_queue(
-                dataset=[{"orgId": org_id, "service": parsed_data.get("service"), "model": model, "success": True, "inputTokens": 0, "outputTokens": 0}],
-                history_params={"user": parsed_data.get("user", ""), "message": "", "thread_id": parsed_data.get("thread_id"), "sub_thread_id": parsed_data.get("sub_thread_id"), "message_id": message_id, "bridge_id": bridge_id, "org_id": org_id, "service": parsed_data.get("service"), "model": model, "response": {"data": {"finish_reason": "stop"}}, "plans": final_plan},
-                version_id=parsed_data.get("version_id")
+            # Update the history entry that was created during planning
+            plan_message_id = (final_plan or {}).get("message_id") or message_id
+            asyncio.create_task(
+                publish_plan_history_update(
+                    message_id=plan_message_id,
+                    final_plan=final_plan,
+                    history_params={
+                        "message": formatted["data"]["content"],
+                        "finish_reason": "stop",
+                        "status": (final_plan or {}).get("state") == "completed",
+                    },
+                )
             )
 
         elif action == "cancel":
@@ -243,6 +292,26 @@ async def _stream_plan_action(streamer, action, parsed_data, bridge_configuratio
                 message_id=message_id,
                 finish_reason="stop",
                 accumulated_data=_format_plan_response(plan, message_id, model),
+            )
+            # Persist initial history entry — execution phases will update it by message_id
+            asyncio.create_task(
+                _publish_history_to_queue(
+                    dataset=[_build_plan_dataset(parsed_data)],
+                    history_params={
+                        "user": parsed_data.get("user", ""),
+                        "message": "",
+                        "thread_id": thread_id,
+                        "sub_thread_id": sub_thread_id,
+                        "message_id": message_id,
+                        "bridge_id": bridge_id,
+                        "org_id": org_id,
+                        "service": parsed_data.get("service"),
+                        "model": model,
+                        "response": {"data": {"finish_reason": "planning"}},
+                        "plans": plan,
+                    },
+                    version_id=parsed_data.get("version_id"),
+                )
             )
             # Save sub_thread so it appears in the thread list (same as non-plan mode)
             asyncio.create_task(
@@ -268,6 +337,19 @@ async def _stream_plan_action(streamer, action, parsed_data, bridge_configuratio
                 message_id=message_id,
                 finish_reason="stop",
                 accumulated_data=_format_plan_response(plan, message_id, model),
+            )
+            # Update the existing history entry with the revised plan
+            plan_message_id = plan.get("message_id") or message_id
+            asyncio.create_task(
+                publish_plan_history_update(
+                    message_id=plan_message_id,
+                    final_plan=plan,
+                    history_params={
+                        "message": "",
+                        "finish_reason": "planning",
+                        "status": True,
+                    },
+                )
             )
 
     except Exception as e:

--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -215,6 +215,7 @@ def parse_request_body(request_body):
         "thread_flag": body.get("thread_flag") or False,
         "files": body.get("files") or [],
         "fall_back": body.get("settings", {}).get("fall_back") or {},
+        "skip_history": body.get("skip_history", False),
         "guardrails": body.get("settings", {}).get("guardrails") or {},
         "testcase_data": body.get("testcase_data") or {},
         "is_embed": body.get("is_embed"),
@@ -698,6 +699,11 @@ async def process_background_tasks(
     Also handles orchestrator mode where multiple agents are saved in a single entry.
     History and metrics are now published to the log queue for Node.js to save to DB.
     """
+    # Primary-agent sub-tasks inside plan mode skip per-call history; the
+    # single final plan result is saved by todo_handler after full execution.
+    if parsed_data.get("skip_history"):
+        return
+
     orchestrator_flag = parsed_data.get("orchestrator_flag") or parsed_data.get("body", {}).get("orchestrator_flag")
 
     is_transfer_chain = (
@@ -806,6 +812,10 @@ async def process_background_tasks(
 
 
 async def process_background_tasks_for_error(parsed_data, error):
+    # Primary-agent sub-tasks inside plan mode skip per-call history.
+    if parsed_data.get("skip_history"):
+        return
+
     tasks = [
         send_alert(
             bridge_id=parsed_data["bridge_id"],


### PR DESCRIPTION
…tion

- Introduced `publish_plan_history_update` to log updates for plan history after execution.
- Updated `_execute_single_task` to conditionally skip history for primary-agent sub-tasks.
- Modified `create_plan` to include `message_id` for history tracking.
- Enhanced `_stream_plan_action` to publish history updates based on final plan results.

These changes improve the tracking and logging of plan execution history, ensuring better integration with the overall task management system.