### PR TITLE
Enhance plan history update functionality

### DIFF
--- a/src/db_services/metrics_service.py
+++ b/src/db_services/metrics_service.py
@@ -389,28 +389,113 @@ def build_orchestrator_log_data(transfer_chain, thread_info=None):
     }
 
 
-async def publish_plan_history_update(message_id, final_plan, history_params):
+async def publish_plan_history_update(
+    *,
+    parsed_data,
+    final_plan,
+    main_agent_metrics=None,
+    history_params_extra=None,
+):
     """
     Publish an update_history message to the log queue so Node.js can update
-    an existing history entry (identified by message_id) once plan execution
-    is complete.  The initial entry was created during the planning phase with
-    the same message_id.
+    the existing conversation_logs row (identified by message_id) once plan
+    execution is complete.
+
+    The initial row was created during the planning phase with the full
+    conversation-log shape but empty metrics.  Here we build the same full
+    shape, enriched with aggregated main-agent telemetry (tokens, latency,
+    reasoning, tools_call_data, etc.) collected by the executor.  The Node
+    consumer whitelist-updates whatever fields it finds in the payload, so
+    this is forward-compatible.
 
     Args:
-        message_id: The message_id that was stored in the plan when it was created.
+        parsed_data: The request dict (has bridge_id, thread_id, sub_thread_id,
+                     org_id, service, model, message_id, user, prompt, version_id).
         final_plan: The fully-executed plan dict with task results.
-        history_params: Dict with optional keys: message, finish_reason, status.
+        main_agent_metrics: Output of `finalize_main_agent_metrics` from the
+                            executor. None for planning-phase updates where no
+                            execution happened.
+        history_params_extra: Dict with override keys for final message /
+                              finish_reason / status (e.g. completion copy).
     """
     try:
         from ..services.cache_service import make_json_serializable
         from ..services.commonServices.queueService.queueLogService import sub_queue_obj
 
+        metrics = main_agent_metrics or {}
+        extra = history_params_extra or {}
+
+        message_id = (
+            (final_plan or {}).get("message_id")
+            or parsed_data.get("message_id")
+        )
+        if not message_id:
+            logger.error("publish_plan_history_update: missing message_id — cannot update history row")
+            return
+
+        version_id = parsed_data.get("version_id")
+        thread_id = parsed_data.get("thread_id")
+        sub_thread_id = parsed_data.get("sub_thread_id") or thread_id
+
+        # Synthesize the single-element `dataset` that build_history_and_metrics_payload expects.
+        dataset = [{
+            "orgId": parsed_data.get("org_id"),
+            "service": metrics.get("service") or parsed_data.get("service"),
+            "model": metrics.get("model") or parsed_data.get("model"),
+            "success": extra.get("status", metrics.get("success", True)),
+            "inputTokens": metrics.get("input_tokens", 0),
+            "outputTokens": metrics.get("output_tokens", 0),
+            "total_tokens": metrics.get("total_tokens", 0),
+            "expectedCost": metrics.get("expected_cost", 0),
+            "latency": metrics.get("latency") or {},
+            "variables": parsed_data.get("variables") or {},
+            "error": metrics.get("last_error"),
+        }]
+
+        history_params = {
+            "message": extra.get("message", ""),
+            "reasoning": metrics.get("reasoning", ""),
+            "user": parsed_data.get("user", ""),
+            "chatbot_message": "",
+            "error": metrics.get("last_error"),
+            "tools_call_data": metrics.get("tools_call_data", []),
+            "message_id": message_id,
+            "sub_thread_id": sub_thread_id,
+            "thread_id": thread_id,
+            "user_urls": parsed_data.get("user_urls", []),
+            "llm_urls": metrics.get("llm_urls", []),
+            "AiConfig": metrics.get("AiConfig"),
+            "fallback_model": metrics.get("fallback_model") or {},
+            "org_id": parsed_data.get("org_id"),
+            "service": metrics.get("service") or parsed_data.get("service"),
+            "model": metrics.get("model") or parsed_data.get("model"),
+            "firstAttemptError": metrics.get("firstAttemptError"),
+            "bridge_id": parsed_data.get("bridge_id"),
+            "prompt": parsed_data.get("prompt"),
+            "plans": final_plan,
+            "response": {
+                "data": {
+                    "finish_reason": extra.get(
+                        "finish_reason", metrics.get("finish_reason", "stop")
+                    )
+                }
+            },
+        }
+
+        payload = build_history_and_metrics_payload(dataset, history_params, version_id)
+        conversation_log_data = payload["conversation_log_data"]
+
+        # build_history_and_metrics_payload derives `status` from dataset[0].success;
+        # honor an explicit override if the caller provided one.
+        if "status" in extra:
+            conversation_log_data["status"] = extra["status"]
+
+        # `plans` is always the authoritative executed plan.
+        conversation_log_data["plans"] = final_plan
+
         update_data = {
             "message_id": str(message_id),
-            "llm_message": history_params.get("message", ""),
-            "plans": final_plan,
-            "finish_reason": history_params.get("finish_reason", "stop"),
-            "status": history_params.get("status", True),
+            **conversation_log_data,
         }
         message = make_json_serializable({"update_history": update_data})
         await sub_queue_obj.publish_message(message)

--- a/src/services/todo/executor_service.py
+++ b/src/services/todo/executor_service.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import json
+import time
 import uuid
 
 from globals import logger
@@ -8,6 +9,162 @@ from src.services.todo import plan_store
 
 
 TERMINAL_STATUSES = {"completed", "failed", "skipped", "waiting_for_user"}
+
+
+def _init_main_agent_metrics():
+    """
+    Aggregate container for main-agent task telemetry. Primary-agent sub-tasks
+    run with skip_history=True, so nothing else persists their tokens/latency/
+    tools/reasoning. We sum them here and hand them to the final history update.
+    """
+    return {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "expected_cost": 0.0,
+        "latency_total": 0.0,
+        "per_task_latency": [],
+        "tools_call_data": [],
+        "_tool_calls_by_id": {},
+        "reasoning_parts": [],
+        "service": None,
+        "model": None,
+        "finish_reason": "stop",
+        "success": True,
+        "firstAttemptError": None,
+        "AiConfig": None,
+        "fallback_model": None,
+        "llm_urls": [],
+        "annotations": [],
+        "last_error": None,
+    }
+
+
+def _merge_task_metrics(
+    metrics,
+    task_id,
+    done_event,
+    collected_tool_calls,
+    reasoning_buf,
+    task_success,
+    error,
+    *,
+    agent_config=None,
+    elapsed_seconds=None,
+    fallback_model=None,
+    service=None,
+    model=None,
+):
+    """Fold a single primary-agent task's telemetry into the shared aggregate.
+
+    `agent_config`, `fallback_model`, `service`, `model`, `elapsed_seconds`
+    come from the executor context (bridge_configurations + wall-clock timing)
+    because the inner chat's SSE `done` event only carries `response.data`
+    and `response.usage`.  AiConfig / fallback_model / latency / firstAttemptError
+    live in `result.historyParams` inside baseService and are never streamed.
+    """
+    if metrics is None:
+        return
+
+    usage = (done_event or {}).get("usage") or {}
+    response = (done_event or {}).get("response") or {}
+    data = response.get("data") or {}
+
+    input_t = usage.get("input_tokens") or 0
+    output_t = usage.get("output_tokens") or 0
+    total_t = usage.get("total_tokens") or (input_t + output_t)
+    cost = usage.get("cost") or usage.get("expected_cost") or 0
+
+    metrics["input_tokens"] += input_t
+    metrics["output_tokens"] += output_t
+    metrics["total_tokens"] += total_t
+    try:
+        metrics["expected_cost"] += float(cost or 0)
+    except (TypeError, ValueError):
+        pass
+
+    # Latency: prefer the provider-reported figure, fall back to wall-clock.
+    provider_latency = data.get("latency")
+    if isinstance(provider_latency, dict):
+        over_all = provider_latency.get("over_all_time") or 0
+    elif isinstance(provider_latency, (int, float)):
+        over_all = provider_latency
+    else:
+        over_all = 0
+    try:
+        over_all = float(over_all or 0)
+    except (TypeError, ValueError):
+        over_all = 0.0
+    if over_all <= 0 and elapsed_seconds is not None:
+        try:
+            over_all = float(elapsed_seconds)
+        except (TypeError, ValueError):
+            over_all = 0.0
+    metrics["latency_total"] += over_all
+    metrics["per_task_latency"].append({"task_id": task_id, "time": round(over_all, 4)})
+
+    effective_model = data.get("model") or model
+    if effective_model and not metrics["model"]:
+        metrics["model"] = effective_model
+    effective_service = response.get("service") or service
+    if effective_service and not metrics["service"]:
+        metrics["service"] = effective_service
+
+    if response.get("firstAttemptError"):
+        metrics["firstAttemptError"] = response["firstAttemptError"]
+
+    # AiConfig = the bridge's customConfig sent to the LLM.  Pulled from the
+    # bridge configuration we already have in hand.
+    if agent_config and not metrics["AiConfig"]:
+        metrics["AiConfig"] = agent_config
+
+    if fallback_model and not metrics["fallback_model"]:
+        metrics["fallback_model"] = fallback_model
+
+    if response.get("llm_urls"):
+        metrics["llm_urls"].extend(response["llm_urls"])
+    if response.get("annotations"):
+        metrics["annotations"].extend(response["annotations"])
+
+    if reasoning_buf:
+        metrics["reasoning_parts"].append("".join(reasoning_buf))
+
+    if collected_tool_calls:
+        metrics["tools_call_data"].extend(collected_tool_calls)
+
+    if not task_success:
+        metrics["success"] = False
+        metrics["finish_reason"] = "error"
+        if error:
+            metrics["last_error"] = str(error)
+
+
+def finalize_main_agent_metrics(metrics):
+    """Shape the aggregate into the fields needed by the history payload."""
+    if not metrics:
+        return None
+    return {
+        "input_tokens": metrics["input_tokens"],
+        "output_tokens": metrics["output_tokens"],
+        "total_tokens": metrics["total_tokens"],
+        "expected_cost": metrics["expected_cost"],
+        "latency": {
+            "over_all_time": metrics["latency_total"],
+            "per_task": metrics["per_task_latency"],
+        },
+        "tools_call_data": metrics["tools_call_data"],
+        "reasoning": "\n".join(p for p in metrics["reasoning_parts"] if p),
+        "service": metrics["service"],
+        "model": metrics["model"],
+        "finish_reason": metrics["finish_reason"],
+        "success": metrics["success"],
+        "firstAttemptError": metrics["firstAttemptError"],
+        "AiConfig": metrics["AiConfig"],
+        "fallback_model": metrics["fallback_model"] or {},
+        "llm_urls": metrics["llm_urls"],
+        "annotations": metrics["annotations"],
+        "last_error": metrics["last_error"],
+    }
 
 
 def _get_runnable_tasks(tasks):
@@ -49,11 +206,15 @@ def _is_plan_complete(tasks):
     return all(t["status"] in TERMINAL_STATUSES for t in tasks.values())
 
 
-async def _execute_single_task(task_id, task, org_id, bridge_id, thread_id, sub_thread_id, bridge_configurations, plan, streamer=None):
+async def _execute_single_task(task_id, task, org_id, bridge_id, thread_id, sub_thread_id, bridge_configurations, plan, streamer=None, main_agent_metrics=None):
     """Execute a single task by calling the appropriate agent directly.
     
     When `streamer` is provided, delta/reasoning/tool events from the agent's
     stream are forwarded to the client in real-time, tagged with `task_id`.
+
+    When `main_agent_metrics` is provided and the task runs on the main bridge,
+    per-task tokens / latency / reasoning / tool_calls are folded into the
+    aggregate so the final history update can persist them.
     """
     assigned_agent = task.get("assigned_agent") or bridge_id
     # A task is a "primary-agent sub-task" when no explicit agent was assigned
@@ -61,11 +222,14 @@ async def _execute_single_task(task_id, task, org_id, bridge_id, thread_id, sub_
     # per-sub-task history so the conversation log shows only the final plan
     # result saved by todo_handler, not every intermediate LLM call.
     is_primary_agent_task = not task.get("assigned_agent") or task.get("assigned_agent") == bridge_id
+    aggregate_metrics = main_agent_metrics if is_primary_agent_task else None
 
     task_description = task.get("task_description", task.get("title", ""))
     human_response = task.get("human_response")
     if human_response:
         task_description = f"{task_description}\n\nHuman Response: {human_response}"
+
+    task_started_at = time.perf_counter() if aggregate_metrics is not None else None
 
     try:
         from src.services.commonServices.common import chat_multiple_agents
@@ -119,6 +283,9 @@ async def _execute_single_task(task_id, task, org_id, bridge_id, thread_id, sub_
         elif hasattr(response, "body_iterator"):
             accumulated_content = []
             done_event = None
+            reasoning_parts = []
+            tool_calls_by_id = {}
+            tool_calls_order = []
             async for chunk in response.body_iterator:
                 if isinstance(chunk, bytes):
                     chunk = chunk.decode("utf-8")
@@ -140,34 +307,85 @@ async def _execute_single_task(task_id, task, org_id, bridge_id, thread_id, sub_
                             await streamer.emit_task_delta(task_id, content_piece)
 
                     elif evt_type == "reasoning":
+                        reasoning_piece = event.get("content", "")
+                        if aggregate_metrics is not None and reasoning_piece:
+                            reasoning_parts.append(reasoning_piece)
                         if streamer:
-                            await streamer.emit_task_reasoning(task_id, event.get("content", ""))
+                            await streamer.emit_task_reasoning(task_id, reasoning_piece)
 
                     elif evt_type == "tool_call":
+                        call_id = event.get("call_id", "")
+                        if aggregate_metrics is not None:
+                            entry = {
+                                "task_id": task_id,
+                                "call_id": call_id,
+                                "name": event.get("name", ""),
+                                "args": event.get("args", {}),
+                                "result": None,
+                            }
+                            if call_id and call_id not in tool_calls_by_id:
+                                tool_calls_by_id[call_id] = entry
+                                tool_calls_order.append(entry)
+                            elif not call_id:
+                                tool_calls_order.append(entry)
                         if streamer:
                             await streamer.emit_task_tool_call(
                                 task_id,
                                 name=event.get("name", ""),
                                 args=event.get("args", {}),
-                                call_id=event.get("call_id", ""),
+                                call_id=call_id,
                             )
 
                     elif evt_type == "tool_result":
+                        call_id = event.get("call_id", "")
+                        result_content = event.get("content", "")
+                        if aggregate_metrics is not None:
+                            if call_id and call_id in tool_calls_by_id:
+                                tool_calls_by_id[call_id]["result"] = result_content
+                            else:
+                                tool_calls_order.append({
+                                    "task_id": task_id,
+                                    "call_id": call_id,
+                                    "name": event.get("name", ""),
+                                    "args": {},
+                                    "result": result_content,
+                                })
                         if streamer:
                             await streamer.emit_task_tool_result(
                                 task_id,
                                 name=event.get("name", ""),
-                                content=event.get("content", ""),
-                                call_id=event.get("call_id", ""),
+                                content=result_content,
+                                call_id=call_id,
                             )
 
                     elif evt_type == "done":
                         done_event = event
-            
+
             content = "".join(accumulated_content)
             if done_event and done_event.get("response", {}).get("data", {}).get("content"):
                 content = done_event["response"]["data"]["content"]
-            
+
+            if aggregate_metrics is not None:
+                elapsed = (
+                    time.perf_counter() - task_started_at
+                    if task_started_at is not None
+                    else None
+                )
+                _merge_task_metrics(
+                    aggregate_metrics,
+                    task_id,
+                    done_event,
+                    tool_calls_order,
+                    reasoning_parts,
+                    task_success=True,
+                    error=None,
+                    agent_config=current_agent_config.get("configuration"),
+                    elapsed_seconds=elapsed,
+                    fallback_model=current_agent_config.get("fall_back"),
+                    service=current_agent_config.get("service"),
+                    model=(current_agent_config.get("configuration") or {}).get("model"),
+                )
+
             return {"success": True, "result": content}
         else:
             if response.get("success"):
@@ -185,11 +403,18 @@ async def execute_plan(org_id, bridge_id, thread_id, sub_thread_id, bridge_confi
     """
     Execute all tasks respecting dependencies and parallelism.
     If `streamer` is provided, task progress events are emitted live via SSE.
+
+    Returns the finalized main-agent metrics aggregate (tokens, latency,
+    reasoning, tools_call_data, etc.) so the caller can attach it to the
+    history update. Connected-agent tasks are excluded — they persist their
+    own rows via the normal chat path.
     """
     plan = await plan_store.get_plan(org_id, bridge_id, thread_id, sub_thread_id)
     if not plan:
         logger.error(f"Plan not found for {org_id}/{bridge_id}/{thread_id}/{sub_thread_id}")
-        return
+        return None
+
+    main_agent_metrics = _init_main_agent_metrics()
 
     plan["state"] = "executing"
     await plan_store.update_plan(plan)
@@ -201,10 +426,9 @@ async def execute_plan(org_id, bridge_id, thread_id, sub_thread_id, bridge_confi
     tasks = plan.get("tasks", {})
 
     while True:
-        # Refresh plan from store (in case of external updates like HIL responses)
         plan = await plan_store.get_plan(org_id, bridge_id, thread_id, sub_thread_id)
         if not plan:
-            break
+            return finalize_main_agent_metrics(main_agent_metrics)
         tasks = plan.get("tasks", {})
 
         # Check if all tasks are done
@@ -241,6 +465,7 @@ async def execute_plan(org_id, bridge_id, thread_id, sub_thread_id, bridge_confi
                 task_id, tasks[task_id],
                 org_id, bridge_id, thread_id, sub_thread_id,
                 bridge_configurations, plan, streamer=streamer,
+                main_agent_metrics=main_agent_metrics,
             )
             for task_id in runnable
         ]
@@ -301,6 +526,8 @@ async def execute_plan(org_id, bridge_id, thread_id, sub_thread_id, bridge_confi
         plan["state"] = "failed" if has_failures else "completed"
         await plan_store.update_plan(plan)
         await _emit("plan_completed", {"state": plan["state"], "plan": plan})
+
+    return finalize_main_agent_metrics(main_agent_metrics)
 
 
 async def resume_task(org_id, bridge_id, thread_id, sub_thread_id, task_id, human_response):

--- a/src/services/todo/todo_handler.py
+++ b/src/services/todo/todo_handler.py
@@ -127,7 +127,7 @@ async def _stream_plan_action(streamer, action, parsed_data, bridge_configuratio
             await streamer.emit_delta(json.dumps({"event": "execution_started", "state": "executing"}))
             await streamer.emit_execution()
             # Run executor — stream stays open, task events emitted per task
-            await executor_service.execute_plan(
+            main_agent_metrics = await executor_service.execute_plan(
                 org_id, bridge_id, thread_id, sub_thread_id, bridge_configurations, streamer=streamer
             )
             final_plan = await plan_store.get_plan(org_id, bridge_id, thread_id, sub_thread_id)
@@ -138,13 +138,14 @@ async def _stream_plan_action(streamer, action, parsed_data, bridge_configuratio
                 finish_reason="stop",
                 accumulated_data=formatted,
             )
-            # Update the history entry that was created during planning
-            plan_message_id = (final_plan or {}).get("message_id") or message_id
+            # Update the history entry that was created during planning, enriched
+            # with aggregated main-agent telemetry (tokens, latency, tools, reasoning).
             asyncio.create_task(
                 publish_plan_history_update(
-                    message_id=plan_message_id,
+                    parsed_data=parsed_data,
                     final_plan=final_plan,
-                    history_params={
+                    main_agent_metrics=main_agent_metrics,
+                    history_params_extra={
                         "message": formatted["data"]["content"],
                         "finish_reason": "stop",
                         "status": (final_plan or {}).get("state") == "completed",
@@ -199,7 +200,7 @@ async def _stream_plan_action(streamer, action, parsed_data, bridge_configuratio
             # Resume execution — live events are streamed through the same connection
             plan["state"] = "approved"
             await plan_store.update_plan(plan)
-            await executor_service.execute_plan(
+            main_agent_metrics = await executor_service.execute_plan(
                 org_id, bridge_id, thread_id, sub_thread_id, bridge_configurations, streamer=streamer
             )
             final_plan = await plan_store.get_plan(org_id, bridge_id, thread_id, sub_thread_id)
@@ -210,13 +211,12 @@ async def _stream_plan_action(streamer, action, parsed_data, bridge_configuratio
                 finish_reason="stop",
                 accumulated_data=formatted,
             )
-            # Update the history entry that was created during planning
-            plan_message_id = (final_plan or {}).get("message_id") or message_id
             asyncio.create_task(
                 publish_plan_history_update(
-                    message_id=plan_message_id,
+                    parsed_data=parsed_data,
                     final_plan=final_plan,
-                    history_params={
+                    main_agent_metrics=main_agent_metrics,
+                    history_params_extra={
                         "message": formatted["data"]["content"],
                         "finish_reason": "stop",
                         "status": (final_plan or {}).get("state") == "completed",
@@ -248,7 +248,7 @@ async def _stream_plan_action(streamer, action, parsed_data, bridge_configuratio
             # Emit execution event and restart executor
             await streamer.emit_delta(json.dumps({"event": "execution_started", "state": "executing"}))
             await streamer.emit_execution()
-            await executor_service.execute_plan(
+            main_agent_metrics = await executor_service.execute_plan(
                 org_id, bridge_id, thread_id, sub_thread_id, bridge_configurations, streamer=streamer
             )
             final_plan = await plan_store.get_plan(org_id, bridge_id, thread_id, sub_thread_id)
@@ -259,13 +259,12 @@ async def _stream_plan_action(streamer, action, parsed_data, bridge_configuratio
                 finish_reason="stop",
                 accumulated_data=formatted,
             )
-            # Update the history entry that was created during planning
-            plan_message_id = (final_plan or {}).get("message_id") or message_id
             asyncio.create_task(
                 publish_plan_history_update(
-                    message_id=plan_message_id,
+                    parsed_data=parsed_data,
                     final_plan=final_plan,
-                    history_params={
+                    main_agent_metrics=main_agent_metrics,
+                    history_params_extra={
                         "message": formatted["data"]["content"],
                         "finish_reason": "stop",
                         "status": (final_plan or {}).get("state") == "completed",
@@ -338,13 +337,14 @@ async def _stream_plan_action(streamer, action, parsed_data, bridge_configuratio
                 finish_reason="stop",
                 accumulated_data=_format_plan_response(plan, message_id, model),
             )
-            # Update the existing history entry with the revised plan
-            plan_message_id = plan.get("message_id") or message_id
+            # Update the existing history entry with the revised plan (no execution yet,
+            # so no main-agent metrics — only plans/finish_reason/status move).
             asyncio.create_task(
                 publish_plan_history_update(
-                    message_id=plan_message_id,
+                    parsed_data=parsed_data,
                     final_plan=plan,
-                    history_params={
+                    main_agent_metrics=None,
+                    history_params_extra={
                         "message": "",
                         "finish_reason": "planning",
                         "status": True,


### PR DESCRIPTION
- Refactored `publish_plan_history_update` to accept `parsed_data`, `main_agent_metrics`, and `history_params_extra` for improved flexibility and data handling.
- Updated `_execute_single_task` to aggregate main-agent metrics during task execution, ensuring comprehensive telemetry is captured for history updates.
- Modified `_stream_plan_action` to pass the new metrics and parsed data to `publish_plan_history_update`, enriching the history entry with detailed execution data.

These changes improve the accuracy and completeness of plan execution history tracking, enhancing system responsiveness and data integrity.