### PR TITLE
Refactor planner service and enhance chat handling for plan mode

### DIFF
--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -54,6 +54,7 @@ from src.send_alert import send_alert
 from .response_caching_service import handle_response_caching
 from workflow import execute_advanced_workflow
 from src.services.todo.todo_handler import handle_todo_mode
+from src.services.todo.planner_service import prepare_planner_request
 
 app = FastAPI()
 configurationModel = db["configurations"]
@@ -272,10 +273,15 @@ async def chat(request_body):
             )
 
         if parsed_data.get("mode") == "plan":
-            return await handle_todo_mode(
-                parsed_data=parsed_data,
-                bridge_configurations=bridge_configurations,
-            )
+            # Executor orchestration actions keep the existing pipeline.
+            # The planner LLM call (no action) falls through to chat() with
+            # custom_config mutated to inject the planner prompt + json output.
+            if parsed_data.get("action"):
+                return await handle_todo_mode(
+                    parsed_data=parsed_data,
+                    bridge_configurations=bridge_configurations,
+                )
+            await prepare_planner_request(parsed_data, bridge_configurations, custom_config)
 
         # Execute with retry mechanism
         class_obj = await Helper.create_service_handler(params, parsed_data["service"])
@@ -287,6 +293,17 @@ async def chat(request_body):
 
         # Streaming is SSE-only: if stream=true return StreamingResponse.
         if getattr(class_obj, "stream_mode", False) and getattr(class_obj, "streamer", None):
+            # Plan mode (planner call): frontend expects `start` -> `planning`
+            # -> deltas. Emit both up-front so ordering matches the legacy
+            # planner; baseService.stream's own emit_start is idempotent.
+            if parsed_data.get("mode") == "plan" and not parsed_data.get("action"):
+                await class_obj.streamer.emit_start(
+                    model=parsed_data.get("model") or "",
+                    service=parsed_data.get("service") or "",
+                    bridge_id=str(parsed_data.get("bridge_id") or ""),
+                    message_id=str(parsed_data.get("message_id") or ""),
+                )
+                await class_obj.streamer.emit_planning()
             if injected_streamer:
                 # Agent-transfer: existing SSE connection owned by the caller — background task, no new StreamingResponse
                 asyncio.create_task(sse_stream_and_finalize(

--- a/src/services/todo/planner_service.py
+++ b/src/services/todo/planner_service.py
@@ -2,18 +2,8 @@ import json
 
 from globals import logger
 from src.services.utils.helper import Helper
-from src.configs.constant import service_name
 from src.services.prebuilt_prompt_service import get_specific_prebuilt_prompt_without_org_service
 from src.services.todo import plan_store
-
-from src.services.commonServices.openAI.runModel import openai_response_stream
-from src.services.commonServices.anthropic.anthropicModelRun import anthropic_stream
-from src.services.commonServices.groq.groqModelRun import groq_stream
-from src.services.commonServices.grok.grokModelRun import grok_stream
-from src.services.commonServices.Google.gemini_modelrun import gemini_modelrun_stream
-from src.services.commonServices.Mistral.mistral_model_run import mistral_stream
-from src.services.commonServices.openRouter.openRouter_modelrun import openrouter_stream
-from src.services.commonServices.baseService.utils import run_stream_and_collect, reasoning_formatter
 
 PLANNER_PROMPT = """
 Role — Task Planning Agent 
@@ -55,21 +45,6 @@ Always return only JSON in the specified format
 }
 
 """
-
-
-# Streaming functions per service — all take (configuration, apikey) positional args
-STREAM_FUNCTIONS = {
-    service_name["openai"]: openai_response_stream,
-    service_name["anthropic"]: anthropic_stream,
-    service_name["groq"]: groq_stream,
-    service_name["grok"]: grok_stream,
-    service_name["gemini"]: gemini_modelrun_stream,
-    service_name["mistral"]: mistral_stream,
-    service_name["open_router"]: openrouter_stream,
-}
-
-# These services need stream=True added to the config dict (SDK-based, not handled internally)
-_NEEDS_STREAM_FLAG = {service_name["groq"], service_name["open_router"]}
 
 
 def _build_agent_context(parsed_data, bridge_configurations):
@@ -146,46 +121,6 @@ def _build_planner_message(user_goal, agent_context, existing_plan=None, user_fe
     return "\n".join(parts)
 
 
-def _build_llm_config(model, service, planner_message, reasoning_config=None, planner_prompt=None):
-    """Build a minimal streaming LLM configuration."""
-    if service == service_name["anthropic"]:
-        config = {
-            "model": model,
-            "system": planner_prompt,
-            "messages": [{"role": "user", "content": planner_message}],
-            "max_tokens": 4096,
-        }
-    elif service == service_name["gemini"]:
-        config = {
-            "model": model,
-            "contents": [
-                {"role": "user", "parts": [{"text": planner_prompt + "\n\n" + planner_message}]},
-            ],
-        }
-    elif service == service_name["openai"]:
-        config = {
-            "model": model,
-            "instructions": planner_prompt,
-            "input": [{"type": "message", "role": "user", "content": planner_message}],
-        }
-    else:
-        config = {
-            "model": model,
-            "messages": [
-                {"role": "system", "content": planner_prompt},
-                {"role": "user", "content": planner_message},
-            ],
-        }
-        if service in _NEEDS_STREAM_FLAG:
-            config["stream"] = True
-
-    if reasoning_config:
-        config["reasoning"] = reasoning_config
-        reasoning_formatter(service, config)
-
-    return config
-
-
 def _parse_plan_json(content):
     """Parse JSON plan from LLM content, stripping markdown fences if present."""
     if "```json" in content:
@@ -198,46 +133,8 @@ def _parse_plan_json(content):
         raise ValueError(f"Planner returned invalid JSON: {e}\nContent: {content[:500]}")
 
 
-async def _call_planner_streaming(planner_message, parsed_data, bridge_configurations, streamer, planner_prompt):
-    """
-    Call the LLM in streaming mode. Tokens are emitted to `streamer` as they arrive.
-    Returns the parsed plan JSON dict after the stream completes.
-    """
-    main_bridge_id = parsed_data["bridge_id"]
-    main_config = bridge_configurations.get(main_bridge_id, {})
-
-    model = main_config.get("configuration", {}).get("model", parsed_data.get("model"))
-    service = main_config.get("service", parsed_data.get("service"))
-    apikey = main_config.get("apikey", parsed_data.get("apikey"))
-    reasoning_config = main_config.get("configuration", {}).get("reasoning")
-
-    stream_fn = STREAM_FUNCTIONS.get(service)
-    if not stream_fn:
-        raise ValueError(f"Unsupported service for planner: {service}")
-
-    config = _build_llm_config(model, service, planner_message, reasoning_config=reasoning_config, planner_prompt=planner_prompt)
-
-    # All stream functions take (configuration, apikey) as positional args
-    generator = stream_fn(config, apikey)
-    stream_state = await run_stream_and_collect(generator, streamer)
-
-    if stream_state.get("error_in_stream"):
-        raise ValueError(f"Planner stream error: {stream_state['error_in_stream']}")
-
-    content = "".join(stream_state.get("accumulated_content", []))
-    if not content:
-        raise ValueError("Planner returned empty response")
-
-    return _parse_plan_json(content)
-
 def _build_planner_system_prompt(prompt, agent_context):
     return f"{prompt}\n\n ***user agent system prompt*** : {agent_context}"
-
-
-def _prepare_planner_prompt(parsed_data, bridge_configurations):
-    """Build the planner system prompt with agent context. Reusable across create_plan and update_plan."""
-    agent_context = _build_agent_context(parsed_data, bridge_configurations)
-    return _build_planner_system_prompt(PLANNER_PROMPT, agent_context)
 
 
 async def _get_planner_prompt_from_db(default_prompt):
@@ -251,51 +148,37 @@ async def _get_planner_prompt_from_db(default_prompt):
     return default_prompt
 
 
-async def create_plan(parsed_data, bridge_configurations, streamer):
-    """Create a new plan, streaming tokens to `streamer`."""
-    user_goal = parsed_data["user"]
+async def prepare_planner_request(parsed_data, bridge_configurations, custom_config):
+    """Mutate parsed_data + custom_config so the normal chat() pipeline serves
+    the planner call. Injects the planner system prompt (merged with the user
+    agent's prompt as context) and forces json_object response. For update
+    calls (existing plan in Redis), folds the current plan into the user
+    message so the LLM can revise it based on the new feedback.
+    """
     db_planner_prompt = await _get_planner_prompt_from_db(PLANNER_PROMPT)
     planner_prompt = _build_planner_system_prompt(
-        db_planner_prompt, _build_agent_context(parsed_data, bridge_configurations)
+        db_planner_prompt,
+        _build_agent_context(parsed_data, bridge_configurations),
     )
-    planner_message = _build_planner_message(user_goal, "")
-    plan_data = await _call_planner_streaming(planner_message, parsed_data, bridge_configurations, streamer, planner_prompt)
+    original_prompt = (parsed_data.get("configuration") or {}).get("prompt") or ""
+    merged_prompt = f"{planner_prompt}\n\n***user agent system prompt***: {original_prompt}"
+    parsed_data.setdefault("configuration", {})["prompt"] = merged_prompt
 
-    plan = {
-        "goal": plan_data.get("goal", user_goal),
-        "state": "planning",
-        "bridge_id": parsed_data["bridge_id"],
-        "org_id": parsed_data["org_id"],
-        "thread_id": parsed_data["thread_id"],
-        "sub_thread_id": parsed_data.get("sub_thread_id") or parsed_data["thread_id"],
-        "tasks": plan_data.get("tasks", {}),
-        # Persisted so execution phases can update the same history entry
-        "message_id": parsed_data.get("message_id", ""),
-    }
+    custom_config["response_type"] = {"type": "json_object"}
 
-    await plan_store.save_plan(plan)
-    return plan
-
-
-async def update_plan(existing_plan, user_feedback, parsed_data, bridge_configurations, streamer):
-    """Update an existing plan based on user feedback, streaming tokens to `streamer`."""
-    db_planner_prompt = await _get_planner_prompt_from_db(PLANNER_PROMPT)
-    planner_prompt = _build_planner_system_prompt(
-        db_planner_prompt, _build_agent_context(parsed_data, bridge_configurations)
+    existing_plan = await plan_store.get_plan(
+        parsed_data["org_id"],
+        parsed_data["bridge_id"],
+        parsed_data["thread_id"],
+        parsed_data.get("sub_thread_id") or parsed_data["thread_id"],
     )
-    agent_context = _build_agent_context(parsed_data, bridge_configurations)
-    planner_message = _build_planner_message(
-        existing_plan["goal"],
-        agent_context,
-        existing_plan=existing_plan,
-        user_feedback=user_feedback,
-    )
+    if existing_plan:
+        user_feedback = parsed_data.get("user", "")
+        parsed_data["user"] = _build_planner_message(
+            existing_plan.get("goal", user_feedback),
+            "",
+            existing_plan=existing_plan,
+            user_feedback=user_feedback,
+        )
 
-    plan_data = await _call_planner_streaming(planner_message, parsed_data, bridge_configurations, streamer, planner_prompt)
 
-    existing_plan["tasks"] = plan_data.get("tasks", existing_plan["tasks"])
-    existing_plan["goal"] = plan_data.get("goal", existing_plan["goal"])
-    existing_plan["state"] = "planning"
-
-    await plan_store.update_plan(existing_plan)
-    return existing_plan

--- a/src/services/todo/todo_handler.py
+++ b/src/services/todo/todo_handler.py
@@ -5,9 +5,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from globals import logger
 from src.services.commonServices.streaming_service import StreamingService
-from src.services.todo import executor_service, plan_store, planner_service
-from src.controllers.conversationController import save_sub_thread_id_and_name
-from src.services.utils.common_utils import _publish_history_to_queue
+from src.services.todo import executor_service, plan_store
 from src.db_services.metrics_service import publish_plan_history_update
 
 
@@ -78,19 +76,6 @@ def _format_plan_response(plan, message_id, model="", finish_reason="completed",
             "total_tokens": 0,
             "cost": 0,
         },
-    }
-
-
-def _build_plan_dataset(parsed_data):
-    """Minimal dataset dict for a plan-mode history entry (no token tracking at plan level)."""
-    return {
-        "orgId": parsed_data.get("org_id"),
-        "service": parsed_data.get("service"),
-        "model": parsed_data.get("model", ""),
-        "success": True,
-        "inputTokens": 0,
-        "outputTokens": 0,
-        "total_tokens": 0,
     }
 
 
@@ -280,76 +265,6 @@ async def _stream_plan_action(streamer, action, parsed_data, bridge_configuratio
                 message_id=message_id,
                 finish_reason="stop",
                 accumulated_data=_format_plan_response(existing_plan, message_id, model, finish_reason="cancelled"),
-            )
-
-        elif not existing_plan:
-            # Create new plan — LLM tokens stream live via streamer
-            await streamer.emit_planning()
-            plan = await planner_service.create_plan(parsed_data, bridge_configurations, streamer)
-            await streamer.emit_done(
-                usage={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
-                message_id=message_id,
-                finish_reason="stop",
-                accumulated_data=_format_plan_response(plan, message_id, model),
-            )
-            # Persist initial history entry — execution phases will update it by message_id
-            asyncio.create_task(
-                _publish_history_to_queue(
-                    dataset=[_build_plan_dataset(parsed_data)],
-                    history_params={
-                        "user": parsed_data.get("user", ""),
-                        "message": "",
-                        "thread_id": thread_id,
-                        "sub_thread_id": sub_thread_id,
-                        "message_id": message_id,
-                        "bridge_id": bridge_id,
-                        "org_id": org_id,
-                        "service": parsed_data.get("service"),
-                        "model": model,
-                        "response": {"data": {"finish_reason": "planning"}},
-                        "plans": plan,
-                    },
-                    version_id=parsed_data.get("version_id"),
-                )
-            )
-            # Save sub_thread so it appears in the thread list (same as non-plan mode)
-            asyncio.create_task(
-                save_sub_thread_id_and_name(
-                    thread_id,
-                    sub_thread_id,
-                    org_id,
-                    parsed_data.get("thread_flag", False),
-                    parsed_data.get("response_format"),
-                    bridge_id,
-                    parsed_data.get("user", ""),
-                )
-            )
-
-        else:
-            # Update existing plan — LLM tokens stream live via streamer
-            await streamer.emit_planning()
-            plan = await planner_service.update_plan(
-                existing_plan, parsed_data.get("user", ""), parsed_data, bridge_configurations, streamer
-            )
-            await streamer.emit_done(
-                usage={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
-                message_id=message_id,
-                finish_reason="stop",
-                accumulated_data=_format_plan_response(plan, message_id, model),
-            )
-            # Update the existing history entry with the revised plan (no execution yet,
-            # so no main-agent metrics — only plans/finish_reason/status move).
-            asyncio.create_task(
-                publish_plan_history_update(
-                    parsed_data=parsed_data,
-                    final_plan=plan,
-                    main_agent_metrics=None,
-                    history_params_extra={
-                        "message": "",
-                        "finish_reason": "planning",
-                        "status": True,
-                    },
-                )
             )
 
     except Exception as e:

--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -761,6 +761,37 @@ async def _update_history_redis(dataset, history_params, version_id, thread_info
         await store_in_cache(cache_key, float(total_tokens))
 
 
+async def _save_plan_from_result(parsed_data, result):
+    """Parse the planner LLM JSON out of `result` and persist the plan to Redis.
+    Also attaches the parsed plan to `historyParams["plans"]` so the history
+    row carries the same `plans` field the legacy todo_handler used to save.
+    """
+    from src.services.todo import plan_store
+    from src.services.todo.planner_service import _parse_plan_json
+
+    try:
+        response = (result.get("historyParams") or {}).get("response") or result.get("response") or {}
+        content = (response.get("data") or {}).get("content") or ""
+        if not content:
+            return
+        plan_json = _parse_plan_json(content)
+        plan = {
+            "goal": plan_json.get("goal", parsed_data.get("user", "")),
+            "state": "planning",
+            "bridge_id": parsed_data["bridge_id"],
+            "org_id": parsed_data["org_id"],
+            "thread_id": parsed_data["thread_id"],
+            "sub_thread_id": parsed_data.get("sub_thread_id") or parsed_data["thread_id"],
+            "tasks": plan_json.get("tasks", {}),
+            "message_id": parsed_data.get("message_id", ""),
+        }
+        await plan_store.save_plan(plan)
+        if result.get("historyParams") is not None:
+            result["historyParams"]["plans"] = plan
+    except Exception as err:
+        logger.error(f"Failed to save plan from chat result: {err}")
+
+
 async def process_background_tasks(
     parsed_data, result, params, thread_info, transfer_request_id=None, bridge_configurations=None
 ):
@@ -774,6 +805,11 @@ async def process_background_tasks(
     # single final plan result is saved by todo_handler after full execution.
     if parsed_data.get("skip_history"):
         return
+
+    # Plan mode: parse the LLM JSON, save to Redis, and thread the parsed plan
+    # into historyParams so the conversation log persists `plans`.
+    if parsed_data.get("mode") == "plan" and not parsed_data.get("action"):
+        await _save_plan_from_result(parsed_data, result)
 
     orchestrator_flag = parsed_data.get("orchestrator_flag") or parsed_data.get("body", {}).get("orchestrator_flag")
 


### PR DESCRIPTION
- Introduced `prepare_planner_request` to streamline the integration of planner requests into the chat pipeline, allowing for better handling of plan mode without direct action.
- Updated the `chat` function to accommodate planner orchestration, ensuring that the planner LLM call is properly managed and integrated with existing chat functionality.
- Added `_save_plan_from_result` to persist planner results to Redis and ensure that the conversation history retains the relevant plan data.
- Removed deprecated streaming functions and unnecessary code from `planner_service.py` to improve clarity and maintainability.

These changes enhance the planner's functionality and improve the overall responsiveness of the chat service in plan mode.