### PR TITLE
Fix model configuration loading logic to correctly skip level 0 confi…

### DIFF
--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -403,7 +403,7 @@ async def load_model_configuration(model, configuration, service):
             and (config["level"] == 0 or config["level"] == 1 or config["level"] == 2)
             or key in configuration
         ):
-            if config.get("level") == 0 or key not in configuration:
+            if config.get("level") == 0 and key not in configuration:
                 continue
             custom_config[key] = configuration.get(key, config["default"])
 


### PR DESCRIPTION
…gs not in the configuration (#1465)

Updated the condition in `load_model_configuration` to ensure that level 0 configurations are only skipped when the key is not present in the configuration, preventing unintended filtering of valid parameters.