### PR TITLE
Add folder-level post_tool support with AI response override capability

### DIFF
--- a/src/db_services/ConfigurationServices.py
+++ b/src/db_services/ConfigurationServices.py
@@ -714,12 +714,63 @@ async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None)
                         }
                     }
                 },
+                # Stage 8b: Lookup folder post_tool from apicalls collection
+                {
+                    "$lookup": {
+                        "from": "apicalls",
+                        "let": {
+                            "post_tool_id_obj": {
+                                "$cond": [
+                                    {"$ne": ["$config.post_tool_id", None]},
+                                    {
+                                        "$convert": {
+                                            "input": "$config.post_tool_id",
+                                            "to": "objectId",
+                                            "onError": None,
+                                            "onNull": None,
+                                        }
+                                    },
+                                    None,
+                                ]
+                            }
+                        },
+                        "pipeline": [
+                            {"$match": {"$expr": {"$eq": ["$_id", "$$post_tool_id_obj"]}}},
+                            {
+                                "$addFields": {
+                                    "_id": {"$toString": "$_id"},
+                                    "bridge_ids": {
+                                        "$map": {
+                                            "input": "$bridge_ids",
+                                            "as": "bid",
+                                            "in": {"$toString": "$$bid"},
+                                        }
+                                    },
+                                }
+                            },
+                        ],
+                        "as": "folder_post_tool_docs",
+                    }
+                },
+                # Stage 8c: Extract folder_post_tool
+                {
+                    "$addFields": {
+                        "folder_post_tool": {
+                            "$cond": [
+                                {"$gt": [{"$size": "$folder_post_tool_docs"}, 0]},
+                                {"$arrayElemAt": ["$folder_post_tool_docs", 0]},
+                                None,
+                            ]
+                        }
+                    }
+                },
                 # Stage 9: Project folder fields including tools and variables
                 {
                     "$project": {
                         "folder_apikeys": 1,
                         "folder_tools": 1,
                         "folder_pre_tool": 1,
+                        "folder_post_tool": 1,
                         "type": 1,
                         "wrapper_id": 1,
                         "folder_limit": {"$ifNull": ["$folder_limit", 0]},
@@ -729,6 +780,7 @@ async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None)
                         "apikey_object_id": 1,
                         "tools_id": "$config.tools_id",
                         "pre_tool_id": "$config.pre_tool_id",
+                        "post_tool_id": "$config.post_tool_id",
                         "variables_path": {"$ifNull": ["$config.variables_path", {}]},
                         "folder_prompt": "$config.prompt",
                     }
@@ -771,6 +823,10 @@ async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None)
                 if folder_pre_tool_id and folder_pre_tool_id not in bridge_data["pre_tools"]:
                     bridge_data["pre_tools"].append(folder_pre_tool_id)
                     bridge_data["pre_tools_data"].append(folder_pre_tool)
+
+            # Merge folder_post_tool into bridge_data
+            if folder_result and folder_result[0].get("folder_post_tool"):
+                bridge_data["folder_post_tool"] = folder_result[0]["folder_post_tool"]
 
             # Merge folder variables_path into bridge's variables_path
             if folder_result and folder_result[0].get("variables_path"):

--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -568,6 +568,9 @@ async def chat(request_body):
         if not parsed_data["is_playground"]:
             if result.get("response") and result["response"].get("data"):
                 result["response"]["data"]["message_id"] = parsed_data["message_id"]
+            post_tool_response = await handle_post_tool(parsed_data, result)
+            if post_tool_response and post_tool_response.get("status") == 1 and post_tool_response.get("response") is not None:
+                result["response"]["data"]["content"] = post_tool_response.get("response")
             await sendResponse(
                 parsed_data["response_format"],
                 result["response"],
@@ -579,9 +582,6 @@ async def chat(request_body):
             await process_background_tasks(
                 parsed_data, result, params, thread_info, transfer_request_id, bridge_configurations
             )
-            post_tool_response = await handle_post_tool(parsed_data, result)
-            if post_tool_response and post_tool_response.get("status") == 1 and post_tool_response.get("response") is not None:
-                result["response"]["data"]["content"] = post_tool_response.get("response")
         else:
             if parsed_data.get("testcase_data", {}).get("run_testcase", False):
                 from src.services.commonServices.testcases import process_single_testcase_result

--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -174,9 +174,12 @@ async def chat(request_body):
         # To maintain the API Key status for the original service, because it gets overrited when Fallback is used
         original_service = parsed_data["service"]
         
-        # Setup pre_tools for the current agent with its own variables
-        setup_agent_tools(parsed_data, bridge_configurations, tool_phase="pre")
-        setup_agent_tools(parsed_data, bridge_configurations, tool_phase="post")
+        # Setup pre_tools and post_tool for the current agent with its own variables
+        current_agent_id = parsed_data.get("bridge_id")
+        pre_tools = bridge_configurations.get(current_agent_id, {}).get("pre_tools_data", [])
+        post_tool = bridge_configurations.get(current_agent_id, {}).get("post_tool_data", {})
+        parsed_data["pre_tool_data"] = setup_agent_tools(parsed_data, bridge_configurations, pre_tools)
+        parsed_data["post_tool_data"] = setup_agent_tools(parsed_data, bridge_configurations, post_tool)
         await apply_prompt_wrapper(parsed_data)
 
         # Initialize or retrieve transfer_request_id for tracking transfers

--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -25,6 +25,7 @@ from src.services.utils.common_utils import (
     filter_missing_vars,
     handle_agent_transfer,
     handle_fine_tune_model,
+    handle_post_tool,
     handle_pre_tools,
     initialize_timer,
     load_model_configuration,
@@ -37,6 +38,7 @@ from src.services.utils.common_utils import (
     process_variable_state,
     restructure_json_schema,
     validate_json_schema_configuration,
+    setup_agent_post_tool,
     setup_agent_pre_tools,
     update_usage_metrics,
     process_batch_background_tasks,
@@ -160,6 +162,7 @@ async def chat(request_body):
         
         # Setup pre_tools for the current agent with its own variables
         setup_agent_pre_tools(parsed_data, bridge_configurations)
+        setup_agent_post_tool(parsed_data, bridge_configurations)
         await apply_prompt_wrapper(parsed_data)
 
         # Initialize or retrieve transfer_request_id for tracking transfers
@@ -526,6 +529,9 @@ async def chat(request_body):
             await process_background_tasks(
                 parsed_data, result, params, thread_info, transfer_request_id, bridge_configurations
             )
+            post_tool_response = await handle_post_tool(parsed_data, result)
+            if post_tool_response and post_tool_response.get("status") == 1 and post_tool_response.get("response") is not None:
+                result["response"]["data"]["content"] = post_tool_response.get("response")
         else:
             if parsed_data.get("testcase_data", {}).get("run_testcase", False):
                 from src.services.commonServices.testcases import process_single_testcase_result

--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -38,8 +38,7 @@ from src.services.utils.common_utils import (
     process_variable_state,
     restructure_json_schema,
     validate_json_schema_configuration,
-    setup_agent_post_tool,
-    setup_agent_pre_tools,
+    setup_agent_tools,
     update_usage_metrics,
     process_batch_background_tasks,
     update_cost_usage_and_apikey_status_in_background,
@@ -161,8 +160,8 @@ async def chat(request_body):
         original_service = parsed_data["service"]
         
         # Setup pre_tools for the current agent with its own variables
-        setup_agent_pre_tools(parsed_data, bridge_configurations)
-        setup_agent_post_tool(parsed_data, bridge_configurations)
+        setup_agent_tools(parsed_data, bridge_configurations, tool_phase="pre")
+        setup_agent_tools(parsed_data, bridge_configurations, tool_phase="post")
         await apply_prompt_wrapper(parsed_data)
 
         # Initialize or retrieve transfer_request_id for tracking transfers

--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -38,91 +38,68 @@ from src.services.utils.rich_text_support import process_chatbot_response
 from src.db_services.orchestrator_history_service import orchestrator_collector
 from src.services.utils.api_key_status_helper import mark_apikey_status_from_response
 
-def setup_agent_pre_tools(parsed_data, bridge_configurations):
+def setup_agent_tools(parsed_data, bridge_configurations, tool_phase="pre"):
     """
-    Setup pre_tools for the current agent with its own variables.
-    Populates resolved args for each pre-tool from agent variables.
+    Setup pre or post tools for the current agent with its own variables.
+    tool_phase="pre"  → resolves pre_tools_data list → parsed_data["pre_tools"]
+    tool_phase="post" → resolves single post_tool_data → parsed_data["post_tool_data"]
     """
     current_bridge_id = parsed_data.get("bridge_id")
     if not current_bridge_id or not bridge_configurations:
         return
 
     current_config = bridge_configurations.get(current_bridge_id, {})
-    pre_tools_list = current_config.get("pre_tools_data") or []
     agent_variables = parsed_data.get("variables", {})
-    if not pre_tools_list:
-        return
-    resolved_pre_tools = []
-    for pre_tool in pre_tools_list:
-        tool_type = pre_tool.get("_type")
-        tool_config = pre_tool.get("config", {})
-        tool_args_mapping = pre_tool.get("args", {})  # param -> agent_variable_name
-        resolved_args = dict(tool_config)
 
+    def resolve_args(tool_config, tool_args_mapping, is_custom=False):
+        resolved = dict(tool_config)
         for param, var_name in tool_args_mapping.items():
             if var_name in agent_variables:
-                resolved_args[param] = agent_variables[var_name]
-            elif tool_type != "custom_function":
-                resolved_args[param] = var_name
-        if tool_type == "custom_function":
-            function_data = pre_tool.get("function_data", {})
-            required_params = tool_config.get("required_params", [])
-            for param in required_params:
-                if param not in resolved_args:
-                    if param in agent_variables:
-                        resolved_args[param] = agent_variables[param]
-            resolved_pre_tools.append({
-                "type": "custom_function",
-                "name":  tool_config.get("script_id"),
-                "args": resolved_args,
-            })
-        else:
-            resolved_pre_tools.append({
-                "type": tool_type,
-                "args": resolved_args,
-                "config": tool_config,
-                
-                
-            })
+                resolved[param] = agent_variables[var_name]
+            elif not is_custom:
+                resolved[param] = var_name
+        for param in tool_config.get("required_params", []):
+            if param not in resolved and param in agent_variables:
+                resolved[param] = agent_variables[param]
+        return resolved
 
-    parsed_data["pre_tools"] = resolved_pre_tools
+    if tool_phase == "pre":
+        pre_tools_list = current_config.get("pre_tools_data") or []
+        if not pre_tools_list:
+            return
+        resolved_pre_tools = []
+        for pre_tool in pre_tools_list:
+            tool_type = pre_tool.get("_type")
+            tool_config = pre_tool.get("config", {})
+            tool_args_mapping = pre_tool.get("args", {})
+            is_custom = tool_type == "custom_function"
+            resolved_args = resolve_args(tool_config, tool_args_mapping, is_custom)
+            if is_custom:
+                resolved_pre_tools.append({
+                    "type": "custom_function",
+                    "name": tool_config.get("script_id"),
+                    "args": resolved_args,
+                })
+            else:
+                resolved_pre_tools.append({
+                    "type": tool_type,
+                    "args": resolved_args,
+                    "config": tool_config,
+                })
+        parsed_data["pre_tools"] = resolved_pre_tools
 
-def setup_agent_post_tool(parsed_data, bridge_configurations):
-    """
-    Setup post_tool for the current agent with its own variables.
-    Resolves args from agent variables and sets parsed_data["post_tool_data"].
-    """
-    current_bridge_id = parsed_data.get("bridge_id")
-    if not current_bridge_id or not bridge_configurations:
-        return
-
-    current_config = bridge_configurations.get(current_bridge_id, {})
-    post_tool_data = current_config.get("post_tool_data")
-    if not post_tool_data:
-        return
-
-    tool_config = post_tool_data.get("config", {})
-    tool_args_mapping = post_tool_data.get("args", {})
-    agent_variables = parsed_data.get("variables", {})
-
-    resolved_args = dict(tool_config)
-    required_params = tool_config.get("required_params", [])
-
-    for param, var_name in tool_args_mapping.items():
-        if var_name in agent_variables:
-            resolved_args[param] = agent_variables[var_name]
-        else:
-            resolved_args[param] = var_name
-
-    for param in required_params:
-        if param not in resolved_args and param in agent_variables:
-            resolved_args[param] = agent_variables[param]
-
-    parsed_data["post_tool_data"] = {
-        **post_tool_data,
-        "args": resolved_args,
-        "config": tool_config,
-    }
+    elif tool_phase == "post":
+        post_tool_data = current_config.get("post_tool_data")
+        if not post_tool_data:
+            return
+        tool_config = post_tool_data.get("config", {})
+        tool_args_mapping = post_tool_data.get("args", {})
+        resolved_args = resolve_args(tool_config, tool_args_mapping)
+        parsed_data["post_tool_data"] = {
+            **post_tool_data,
+            "args": resolved_args,
+            "config": tool_config,
+        }
 
 async def handle_agent_transfer(
     result, request_body, bridge_configurations, chat_function, current_bridge_id=None, transfer_request_id=None

--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -87,6 +87,43 @@ def setup_agent_pre_tools(parsed_data, bridge_configurations):
 
     parsed_data["pre_tools"] = resolved_pre_tools
 
+def setup_agent_post_tool(parsed_data, bridge_configurations):
+    """
+    Setup post_tool for the current agent with its own variables.
+    Resolves args from agent variables and sets parsed_data["post_tool_data"].
+    """
+    current_bridge_id = parsed_data.get("bridge_id")
+    if not current_bridge_id or not bridge_configurations:
+        return
+
+    current_config = bridge_configurations.get(current_bridge_id, {})
+    post_tool_data = current_config.get("post_tool_data")
+    if not post_tool_data:
+        return
+
+    tool_config = post_tool_data.get("config", {})
+    tool_args_mapping = post_tool_data.get("args", {})
+    agent_variables = parsed_data.get("variables", {})
+
+    resolved_args = dict(tool_config)
+    required_params = tool_config.get("required_params", [])
+
+    for param, var_name in tool_args_mapping.items():
+        if var_name in agent_variables:
+            resolved_args[param] = agent_variables[var_name]
+        else:
+            resolved_args[param] = var_name
+
+    for param in required_params:
+        if param not in resolved_args and param in agent_variables:
+            resolved_args[param] = agent_variables[param]
+
+    parsed_data["post_tool_data"] = {
+        **post_tool_data,
+        "args": resolved_args,
+        "config": tool_config,
+    }
+
 async def handle_agent_transfer(
     result, request_body, bridge_configurations, chat_function, current_bridge_id=None, transfer_request_id=None
 ):
@@ -220,6 +257,7 @@ def parse_request_body(request_body):
         "guardrails": body.get("settings", {}).get("guardrails") or {},
         "testcase_data": body.get("testcase_data") or {},
         "is_embed": body.get("is_embed"),
+        "post_tool_data": body.get("post_tool_data"),
         "user_id": body.get("user_id"),
         "file_data": body.get("video_data") or {},
         "youtube_url": body.get("youtube_url") or None,
@@ -497,6 +535,42 @@ async def handle_pre_tools(parsed_data, custom_config):
                 response = web_response.get('response')
                 error_msg = f"Error: {response.get('error', 'unknown error') if isinstance(response, dict) else response or 'unknown error'}"
                 parsed_data["variables"]["web_search_pre_result"] = error_msg
+
+async def handle_post_tool(parsed_data, result):
+    """Execute the folder-level post_tool after every AI call (embed only).
+    Awaited directly; returns the post function response to allow the caller to override the AI response."""
+
+    post_tool_data = parsed_data.get("post_tool_data")
+    if not post_tool_data:
+        return
+
+
+    script_id = post_tool_data.get("script_id") or post_tool_data.get("function_name") or post_tool_data.get("endpoint_name")
+    if not script_id:
+        logger.warning("post_tool configured but no script_id / function_name found; skipping")
+        return
+
+    try:
+        args = {
+            **dict(post_tool_data.get("args", {})),
+            "user": parsed_data.get("user"),
+            "_response_type": parsed_data.get("configuration", {}).get("response_type"),
+            "bridge_id": parsed_data.get("bridge_id"),
+            "thread_id": parsed_data.get("thread_id"),
+            "org_id": parsed_data.get("org_id"),
+        }
+        response_data = (result or {}).get("response", {}).get("data") if isinstance(result, dict) else None
+        if response_data:
+            args["ai_response"] = response_data.get("content") or response_data
+
+        post_function_response = await axios_work(
+            args,
+            {"url": f"https://flow.sokt.io/func/{script_id}"},
+        )
+    except Exception as err:
+        logger.error(f"post_tool execution error (script_id={script_id}): {err}")
+    return post_function_response
+
 async def manage_threads(parsed_data):
     thread_id = parsed_data["thread_id"]
     sub_thread_id = parsed_data["sub_thread_id"]
@@ -1698,6 +1772,12 @@ async def sse_stream_and_finalize(class_obj, parsed_data, params, timer, thread_
                 or model_response.get("status")
                 or ""
             )
+            post_tool_response = await handle_post_tool(parsed_data, result)
+            if post_tool_response and post_tool_response.get("status") == 1 and post_tool_response.get("response") is not None:
+                if formatted_response.get("data") is not None:
+                    formatted_response["data"]["content"] = post_tool_response.get("response")
+                if result.get("response", {}).get("data") is not None:
+                    result["response"]["data"]["content"] = post_tool_response.get("response")
             accumulated_payload = None if template_data else formatted_response
             await class_obj.streamer.emit_done(
                 usage=formatted_response.get("usage", {}),

--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -38,17 +38,10 @@ from src.services.utils.rich_text_support import process_chatbot_response
 from src.db_services.orchestrator_history_service import orchestrator_collector
 from src.services.utils.api_key_status_helper import mark_apikey_status_from_response
 
-def setup_agent_tools(parsed_data, bridge_configurations, tool_phase="pre"):
-    """
-    Setup pre or post tools for the current agent with its own variables.
-    tool_phase="pre"  → resolves pre_tools_data list → parsed_data["pre_tools"]
-    tool_phase="post" → resolves single post_tool_data → parsed_data["post_tool_data"]
-    """
+def setup_agent_tools(parsed_data, bridge_configurations, tool_data):
     current_bridge_id = parsed_data.get("bridge_id")
-    if not current_bridge_id or not bridge_configurations:
+    if not current_bridge_id or not bridge_configurations or not tool_data:
         return
-
-    current_config = bridge_configurations.get(current_bridge_id, {})
     agent_variables = parsed_data.get("variables", {})
 
     def resolve_args(tool_config, tool_args_mapping, is_custom=False):
@@ -63,44 +56,38 @@ def setup_agent_tools(parsed_data, bridge_configurations, tool_phase="pre"):
                 resolved[param] = agent_variables[param]
         return resolved
 
-    if tool_phase == "pre":
-        pre_tools_list = current_config.get("pre_tools_data") or []
-        if not pre_tools_list:
-            return
-        resolved_pre_tools = []
-        for pre_tool in pre_tools_list:
-            tool_type = pre_tool.get("_type")
-            tool_config = pre_tool.get("config", {})
-            tool_args_mapping = pre_tool.get("args", {})
-            is_custom = tool_type == "custom_function"
-            resolved_args = resolve_args(tool_config, tool_args_mapping, is_custom)
-            if is_custom:
-                resolved_pre_tools.append({
-                    "type": "custom_function",
-                    "name": tool_config.get("script_id"),
-                    "args": resolved_args,
-                })
-            else:
-                resolved_pre_tools.append({
-                    "type": tool_type,
-                    "args": resolved_args,
-                    "config": tool_config,
-                })
-        parsed_data["pre_tools"] = resolved_pre_tools
-
-    elif tool_phase == "post":
-        post_tool_data = current_config.get("post_tool_data")
-        if not post_tool_data:
-            return
-        tool_config = post_tool_data.get("config", {})
-        tool_args_mapping = post_tool_data.get("args", {})
+    resolved_tools = []
+    if isinstance(tool_data, list):
+        tool = tool_data[0]
+    else:
+        tool_config = tool_data.get("config", {})
+        tool_args_mapping = tool_data.get("args", {})
         resolved_args = resolve_args(tool_config, tool_args_mapping)
-        parsed_data["post_tool_data"] = {
-            **post_tool_data,
+        return {
+            **tool_data,
+            "args": resolved_args,
+            "config": tool_config
+        }
+    tool_type = tool.get("_type")
+    tool_config = tool.get("config", {})
+    tool_args_mapping = tool.get("args", {})
+    is_custom = tool_type == "custom_function"
+    resolved_args = resolve_args(tool_config, tool_args_mapping, is_custom)
+    if is_custom:
+        resolved_tools.append({
+            "type": "custom_function",
+            "name": tool_config.get("script_id"),
+            "args": resolved_args,
+        })
+    else:
+        resolved_tools.append({
+            "type": tool_type,
             "args": resolved_args,
             "config": tool_config,
-        }
-
+        })
+    
+    return resolved_tools
+    
 async def handle_agent_transfer(
     result, request_body, bridge_configurations, chat_function, current_bridge_id=None, transfer_request_id=None
 ):
@@ -1801,6 +1788,12 @@ async def sse_stream_and_finalize(class_obj, parsed_data, params, timer, thread_
                 or model_response.get("status")
                 or ""
             )
+            post_tool_response = await handle_post_tool(parsed_data, result)
+            if post_tool_response and post_tool_response.get("status") == 1 and post_tool_response.get("response") is not None:
+                if formatted_response.get("data") is not None:
+                    formatted_response["data"]["content"] = post_tool_response.get("response")
+                if result.get("response", {}).get("data") is not None:
+                    result["response"]["data"]["content"] = post_tool_response.get("response")
             if not is_nested_stream_call:
                 accumulated_payload = None if template_data else formatted_response
                 await class_obj.streamer.emit_done(
@@ -1810,12 +1803,6 @@ async def sse_stream_and_finalize(class_obj, parsed_data, params, timer, thread_
                     accumulated_data=accumulated_payload,
                 )
                 await class_obj.streamer.close()
-            post_tool_response = await handle_post_tool(parsed_data, result)
-            if post_tool_response and post_tool_response.get("status") == 1 and post_tool_response.get("response") is not None:
-                if formatted_response.get("data") is not None:
-                    formatted_response["data"]["content"] = post_tool_response.get("response")
-                if result.get("response", {}).get("data") is not None:
-                    result["response"]["data"]["content"] = post_tool_response.get("response")
             
         return {"success": True, "response": result.get("response", {})}
     except Exception as err:

--- a/src/services/utils/getConfiguration.py
+++ b/src/services/utils/getConfiguration.py
@@ -182,6 +182,16 @@ async def _prepare_configuration_response(
                 "config": tool_config,
                 "args": tool_args,
             })
+    raw_post_tool = result.get("bridges", {}).get("folder_post_tool") or {}
+    raw_post_tool_script_id = raw_post_tool.get('script_id', {}) if raw_post_tool else {}
+    post_tool_data = None
+    if raw_post_tool:
+        variables_path_post_tool = bridge.get("variables_path", {}).get(raw_post_tool_script_id, {})
+        post_tool_data = {
+            **raw_post_tool,
+            "args": variables_path_post_tool,
+            "config": raw_post_tool.get("config", {}),
+        }
 
     rag_data = bridge.get("doc_ids")
     gpt_memory_context = bridge.get("gpt_memory_context")
@@ -213,6 +223,7 @@ async def _prepare_configuration_response(
     base_config = {
         "configuration": configuration,
         "pre_tools_data": pre_tools_data_for_later,
+        "post_tool_data": post_tool_data,
         "service": service,
         "apikey": apikey,
         "auto_model_select": auto_model_select,


### PR DESCRIPTION
Implemented post_tool execution after AI calls in embed mode, allowing post-processing functions to override AI responses. Added MongoDB aggregation pipeline stages to lookup and extract folder post_tool configuration from apicalls collection. Integrated post_tool setup, execution, and response handling in both streaming and non-streaming modes, with proper variable resolution from agent context.