### PR TITLE
refactor: remove unnecessary first-time plan creation logic in `prepa…

### DIFF
--- a/src/services/todo/planner_service.py
+++ b/src/services/todo/planner_service.py
@@ -201,8 +201,5 @@ async def prepare_planner_request(parsed_data, bridge_configurations, custom_con
             user_goal=user_input,
             user_system_prompt=original_prompt,
         )
-    else:
-        # First-time plan creation: just the user goal
-        parsed_data["user"] = _build_planner_message(user_goal=user_input)
 
 


### PR DESCRIPTION
…re_planner_request`

- Eliminated the conditional block for first-time plan creation, simplifying the function's logic. This change streamlines the preparation of planner requests by directly assigning the user goal without additional checks.

This update enhances code clarity and maintainability in the planner service.