### PR TITLE
refactor: remove save_sub_thread_id_and_name function and related logic

### DIFF
--- a/src/controllers/conversationController.py
+++ b/src/controllers/conversationController.py
@@ -1,14 +1,8 @@
 import traceback
-from datetime import datetime
 
 from globals import logger
 
-from ..configs.constant import bridge_ids
 from ..db_services import conversationDbService as chatbotDbService
-from ..db_services.ConfigurationServices import save_sub_thread_id
-from ..services.cache_service import find_in_cache, store_in_cache
-from ..services.commonServices.baseService.utils import sendResponse
-from ..services.utils.ai_call_util import call_ai_middleware
 
 
 async def getThread(thread_id, sub_thread_id, org_id, bridge_id):
@@ -49,54 +43,4 @@ async def add_tool_call_data_in_history(chats):
     return processed_chats
 
 
-async def save_sub_thread_id_and_name(thread_id, sub_thread_id, org_id, thread_flag, response_format, bridge_id, user):
-    try:
-        # Create Redis cache key for the combination
-        cache_key = f"sub_thread_{org_id}_{bridge_id}_{thread_id}_{sub_thread_id}"
-
-        # Check if already exists in Redis cache
-        cached_result = await find_in_cache(cache_key)
-        if cached_result:
-            logger.info(f"Found cached sub_thread_id for key: {cache_key}")
-            return
-
-        variables = {"user": user}
-        display_name = sub_thread_id
-        message = "generate description"
-        current_time = datetime.now()
-        if thread_flag:
-            display_name = await call_ai_middleware(
-                message, bridge_ids["generate_description"], response_type="text", variables=variables
-            )
-        await save_sub_thread_id(org_id, thread_id, sub_thread_id, display_name, bridge_id, current_time)
-
-        # Store in Redis cache for 48 hours (172800 seconds)
-        cache_data = {
-            "org_id": org_id,
-            "bridge_id": bridge_id,
-            "thread_id": thread_id,
-            "sub_thread_id": sub_thread_id,
-            "display_name": display_name,
-            "created_at": current_time.isoformat(),
-        }
-        await store_in_cache(cache_key, cache_data, ttl=172800)  # 48 hours
-
-        if display_name is not None and display_name != sub_thread_id:
-            response = {
-                "data": {
-                    "display_name": display_name,
-                    "sub_thread_id": sub_thread_id,
-                    "thread_id": thread_id,
-                    "bridge_id": bridge_id,
-                    "created_at": current_time.isoformat(),
-                }
-            }
-            await sendResponse(response_format, response, True)
-
-    except Exception as err:
-        logger.error(f"Error in saving sub thread id and name:, {str(err)}")
-        return {"success": False, "message": str(err)}
-
-
-# Exporting the functions
-__all__ = ["getThread", "save_sub_thread_id_and_name"]
+__all__ = ["getThread"]

--- a/src/db_services/ConfigurationServices.py
+++ b/src/db_services/ConfigurationServices.py
@@ -901,40 +901,6 @@ async def update_bridge(bridge_id=None, update_fields=None, version_id=None, org
     return {"success": True, "result": updated_bridge}
 
 
-async def save_sub_thread_id(
-    org_id, thread_id, sub_thread_id, display_name, bridge_id, current_time
-):  # bridge_id is now a required parameter
-    try:
-        # Build update data with both $set and $setOnInsert in single operation
-        update_data = {
-            "$set": {"bridge_id": bridge_id},
-            "$setOnInsert": {
-                "org_id": org_id,
-                "thread_id": thread_id,
-                "sub_thread_id": sub_thread_id,
-                "created_at": current_time,
-            },
-        }
-
-        # Add display_name to $set if provided
-        if display_name is not None and isinstance(display_name, str):
-            update_data["$set"]["display_name"] = display_name
-
-        result = await threadsModel.find_one_and_update(
-            {"org_id": org_id, "thread_id": thread_id, "sub_thread_id": sub_thread_id, "bridge_id": bridge_id},
-            update_data,
-            upsert=True,
-            return_document=True,
-        )
-        return {
-            "success": True,
-            "message": f"sub_thread_id and bridge_id saved successfully {result}",  # Updated success message
-        }
-    except Exception as error:
-        logger.error(f"Error in save_sub_thread_id: {error}")
-        raise error
-
-
 async def get_agents_data(slug_name, user_email):
     bridges = await configurationModel.find_one(
         {

--- a/src/db_services/metrics_service.py
+++ b/src/db_services/metrics_service.py
@@ -127,6 +127,8 @@ async def create_batch_conversation_logs(batch_id, messages, parsed_data, proces
             batch_history_entries.append(conversation_log_data)
 
         if batch_history_entries:
+            batch_history_entries[0]["thread_flag"] = parsed_data.get("thread_flag")
+            batch_history_entries[0]["response_format"] = parsed_data.get("response_format")
             message = make_json_serializable({"save_batch_history": batch_history_entries})
             await sub_queue_obj.publish_message(message)
 

--- a/src/services/commonServices/baseService/utils.py
+++ b/src/services/commonServices/baseService/utils.py
@@ -555,15 +555,6 @@ async def make_request_data_and_publish_sub_queue(parsed_data, result, params, t
     assistant_message = result.get("historyParams", {}).get("message", "")
 
     data = {
-        "save_sub_thread_id_and_name": {
-            "org_id": parsed_data.get("org_id"),
-            "thread_id": thread_info.get("thread_id") if thread_info else parsed_data.get("thread_id"),
-            "sub_thread_id": thread_info.get("sub_thread_id") if thread_info else parsed_data.get("sub_thread_id"),
-            "thread_flag": parsed_data.get("thread_flag"),
-            "response_format": parsed_data.get("response_format"),
-            "bridge_id": parsed_data.get("bridge_id"),
-            "user": parsed_data.get("user"),
-        },
         "metrics_service": {
             "dataset": [parsed_data.get("usage", {})],
             "history_params": result.get("historyParams", {}),

--- a/src/services/commonServices/reviewer_service.py
+++ b/src/services/commonServices/reviewer_service.py
@@ -24,6 +24,7 @@ from src.services.cache_service import make_json_serializable
 from src.services.commonServices.baseService.utils import make_request_data_and_publish_sub_queue
 from src.services.commonServices.queueService.queueLogService import sub_queue_obj
 from src.services.utils.common_utils import (
+    _attach_sub_thread_extras,
     build_service_params,
     configure_custom_settings,
     create_latency_object,
@@ -169,10 +170,11 @@ async def _publish_reviewer_data(
     Publish the reviewer agent's full queue payload.
 
     Mirrors the main agent's process_background_tasks publish path: builds the
-    same payload via make_request_data_and_publish_sub_queue (save_sub_thread_id_and_name,
-    metrics_service, validateResponse, total_token_calculation, etc.) and appends
-    save_history. The reviewer therefore gets its own sub_thread record, metrics,
-    and history saved on the Node side — same as the main agent.
+    same payload via make_request_data_and_publish_sub_queue (metrics_service,
+    validateResponse, total_token_calculation, etc.) and appends save_history with
+    thread_flag and response_format merged into conversation_log_data so the
+    reviewer's sub_thread record, metrics, and history are all saved on the Node
+    side from a single message.
 
     Independent of the main agent's publish so a reviewer-side failure can't
     block the main agent's history.
@@ -197,18 +199,9 @@ async def _publish_reviewer_data(
             or reviewer_params is None
         ):
             history_params = reviewer_summary.get("history_params") or {}
-            error_payload = {
-                "save_history": [history_payload],
-                "save_sub_thread_id_and_name": {
-                    "org_id": history_params.get("org_id"),
-                    "thread_id": history_params.get("thread_id"),
-                    "sub_thread_id": history_params.get("sub_thread_id"),
-                    "thread_flag": None,
-                    "response_format": {"type": "default"},
-                    "bridge_id": reviewer_summary.get("bridge_id"),
-                    "user": history_params.get("user"),
-                },
-            }
+            history_payload["conversation_log_data"]["thread_flag"] = None
+            history_payload["conversation_log_data"]["response_format"] = {"type": "default"}
+            error_payload = {"save_history": [history_payload]}
             message = make_json_serializable(error_payload)
             await sub_queue_obj.publish_message(message)
             logger.info(
@@ -220,6 +213,7 @@ async def _publish_reviewer_data(
         data = await make_request_data_and_publish_sub_queue(
             reviewer_parsed_data, reviewer_result, reviewer_params, thread_info=None
         )
+        _attach_sub_thread_extras(history_payload["conversation_log_data"], reviewer_parsed_data)
         data["save_history"] = [history_payload]
         message = make_json_serializable(data)
         await sub_queue_obj.publish_message(message)

--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -10,7 +10,6 @@ from config import Config
 from globals import TRANSFER_HISTORY, BadRequestException, logger, try_catch
 from src.configs.model_configuration import model_config_document
 from src.configs.serviceKeys import model_config_change
-from src.controllers.conversationController import save_sub_thread_id_and_name
 from src.db_services.metrics_service import (
     build_history_and_metrics_payload,
     build_orchestrator_log_data,
@@ -708,10 +707,29 @@ def build_service_params(
     }
 
 
-async def _publish_history_to_queue(dataset, history_params, version_id, thread_info=None):
+def _attach_sub_thread_extras(conversation_log_data, parsed_data):
+    conversation_log_data["thread_flag"] = parsed_data.get("thread_flag")
+    conversation_log_data["response_format"] = parsed_data.get("response_format")
+
+
+def _build_orchestrator_sub_thread_data(parsed_data, thread_info=None):
+    return {
+        "org_id": parsed_data.get("org_id"),
+        "thread_id": (thread_info or {}).get("thread_id") or parsed_data.get("thread_id"),
+        "sub_thread_id": (thread_info or {}).get("sub_thread_id") or parsed_data.get("sub_thread_id"),
+        "thread_flag": parsed_data.get("thread_flag"),
+        "response_format": parsed_data.get("response_format"),
+        "bridge_id": parsed_data.get("bridge_id"),
+        "user": parsed_data.get("user"),
+    }
+
+
+async def _publish_history_to_queue(dataset, history_params, version_id, thread_info=None, parsed_data=None):
     """Build history/metrics payload and publish it to the log queue for Node.js to save."""
     try:
         payload = build_history_and_metrics_payload(dataset, history_params, version_id)
+        if parsed_data is not None:
+            _attach_sub_thread_extras(payload["conversation_log_data"], parsed_data)
         message = make_json_serializable({"save_history": [payload]})
         await sub_queue_obj.publish_message(message)
 
@@ -983,6 +1001,7 @@ async def process_background_tasks(
     data = await make_request_data_and_publish_sub_queue(parsed_data, result, params, thread_info)
 
     if history_entries:
+        _attach_sub_thread_extras(history_entries[0]["conversation_log_data"], parsed_data)
         data["save_history"] = history_entries
 
         asyncio.gather(
@@ -991,6 +1010,7 @@ async def process_background_tasks(
         )
 
     if orchestrator_history_data:
+        orchestrator_history_data["sub_thread_data"] = _build_orchestrator_sub_thread_data(parsed_data, thread_info)
         data["save_orchestrator_history"] = orchestrator_history_data
 
     data = make_json_serializable(data)
@@ -1019,16 +1039,10 @@ async def process_background_tasks_for_error(parsed_data, error):
             is_external_error=False,
         ),
         _publish_history_to_queue(
-            [parsed_data["usage"]], parsed_data["historyParams"], parsed_data["version_id"]
-        ),
-        save_sub_thread_id_and_name(
-            parsed_data["thread_id"],
-            parsed_data["sub_thread_id"],
-            parsed_data["org_id"],
-            parsed_data["thread_flag"],
-            parsed_data["response_format"],
-            parsed_data["bridge_id"],
-            parsed_data["user"],
+            [parsed_data["usage"]],
+            parsed_data["historyParams"],
+            parsed_data["version_id"],
+            parsed_data=parsed_data,
         ),
     ]
     await asyncio.gather(*[task for task in tasks if task is not None], return_exceptions=True)
@@ -1050,8 +1064,7 @@ async def process_batch_background_tasks(parsed_data, result, processed_prompts,
     messages = result.get("messages", [])
     
     tasks = []
-    
-    # Task 1: Save batch conversation logs
+
     if batch_id and messages:
         tasks.append(
             create_batch_conversation_logs(
@@ -1059,25 +1072,10 @@ async def process_batch_background_tasks(parsed_data, result, processed_prompts,
                 messages=messages,
                 parsed_data=parsed_data,
                 processed_prompts=processed_prompts,
-                batch_variables=batch_variables
+                batch_variables=batch_variables,
             )
         )
-    
-    # Task 2: Save subthread information (only if thread_id and sub_thread_id exist)
-    if parsed_data.get("thread_id") and parsed_data.get("sub_thread_id"):
-        tasks.append(
-            save_sub_thread_id_and_name(
-                parsed_data["thread_id"],
-                parsed_data["sub_thread_id"],
-                parsed_data["org_id"],
-                parsed_data.get("thread_flag", False),
-                parsed_data.get("response_format", {}),
-                parsed_data["bridge_id"],
-                parsed_data["user"],
-            )
-        )
-    
-    # Execute all tasks in parallel without blocking
+
     if tasks:
         await asyncio.gather(*tasks, return_exceptions=True)
 


### PR DESCRIPTION
- Eliminated the `save_sub_thread_id_and_name` function from `conversationController.py` and its references in the codebase, streamlining the conversation handling process.
- Updated related services and utility functions to remove dependencies on the removed function, enhancing code clarity and maintainability.
- Introduced `_attach_sub_thread_extras` to manage thread-related data more effectively in the context of conversation logs.

This refactor improves the overall structure of the code and reduces unnecessary complexity in managing sub-thread data.