### PR TITLE
Move post-tool handling before sendResponse to ensure modified conten…

### DIFF
--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -567,11 +567,24 @@ async def chat(request_body):
                 success=True,
                 variables=parsed_data.get("variables", {}),
             )
-        
+         
         post_tool_response = await handle_post_tool(parsed_data, result)
-        if post_tool_response and post_tool_response.get("status") == 1 and post_tool_response.get("response") is not None:
-            result["response"]["data"]["content"] = post_tool_response.get("response")
-            result['historyParams']['post_tool_response'] = post_tool_response.get("response")
+        if post_tool_response is not None:
+            post_tool_data = parsed_data.get("post_tool_data", {})
+            flow_hit_id = (post_tool_response.get("metadata") or {}).get("flowHitId")
+            entry = {
+                "id": post_tool_data.get("script_id"),
+                "args": post_tool_data.get("args", {}),
+                "data": post_tool_response,
+                "type":"post_tool",
+                "name": post_tool_data.get("title") or post_tool_data.get("script_id"),
+                "error": post_tool_response.get("status") != 1,
+            }
+            post_tool_log = {flow_hit_id: entry} if flow_hit_id else entry
+            if result.get("historyParams") is not None:
+                result["historyParams"].setdefault("tools_call_data", []).append(post_tool_log)
+            if post_tool_response.get("status") == 1 and post_tool_response.get("response") is not None:
+                result["response"]["data"]["content"] = post_tool_response.get("response")
 
         if not parsed_data["is_playground"]:
             if result.get("response") and result["response"].get("data"):

--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -178,7 +178,7 @@ async def chat(request_body):
         current_agent_id = parsed_data.get("bridge_id")
         pre_tools = bridge_configurations.get(current_agent_id, {}).get("pre_tools_data", [])
         post_tool = bridge_configurations.get(current_agent_id, {}).get("post_tool_data", {})
-        parsed_data["pre_tool_data"] = setup_agent_tools(parsed_data, bridge_configurations, pre_tools)
+        parsed_data["pre_tools"] = setup_agent_tools(parsed_data, bridge_configurations, pre_tools)
         parsed_data["post_tool_data"] = setup_agent_tools(parsed_data, bridge_configurations, post_tool)
         await apply_prompt_wrapper(parsed_data)
 
@@ -568,23 +568,7 @@ async def chat(request_body):
                 variables=parsed_data.get("variables", {}),
             )
          
-        post_tool_response = await handle_post_tool(parsed_data, result)
-        if post_tool_response is not None:
-            post_tool_data = parsed_data.get("post_tool_data", {})
-            flow_hit_id = (post_tool_response.get("metadata") or {}).get("flowHitId")
-            entry = {
-                "id": post_tool_data.get("script_id"),
-                "args": post_tool_data.get("args", {}),
-                "data": post_tool_response,
-                "type":"post_tool",
-                "name": post_tool_data.get("title") or post_tool_data.get("script_id"),
-                "error": post_tool_response.get("status") != 1,
-            }
-            post_tool_log = {flow_hit_id: entry} if flow_hit_id else entry
-            if result.get("historyParams") is not None:
-                result["historyParams"].setdefault("tools_call_data", []).append(post_tool_log)
-            if post_tool_response.get("status") == 1 and post_tool_response.get("response") is not None:
-                result["response"]["data"]["content"] = post_tool_response.get("response")
+        await handle_post_tool(parsed_data, result)
 
         if not parsed_data["is_playground"]:
             if result.get("response") and result["response"].get("data"):

--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -567,13 +567,15 @@ async def chat(request_body):
                 success=True,
                 variables=parsed_data.get("variables", {}),
             )
+        
+        post_tool_response = await handle_post_tool(parsed_data, result)
+        if post_tool_response and post_tool_response.get("status") == 1 and post_tool_response.get("response") is not None:
+            result["response"]["data"]["content"] = post_tool_response.get("response")
+            result['historyParams']['post_tool_response'] = post_tool_response.get("response")
 
         if not parsed_data["is_playground"]:
             if result.get("response") and result["response"].get("data"):
                 result["response"]["data"]["message_id"] = parsed_data["message_id"]
-            post_tool_response = await handle_post_tool(parsed_data, result)
-            if post_tool_response and post_tool_response.get("status") == 1 and post_tool_response.get("response") is not None:
-                result["response"]["data"]["content"] = post_tool_response.get("response")
             await sendResponse(
                 parsed_data["response_format"],
                 result["response"],

--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -501,14 +501,12 @@ async def handle_pre_tools(parsed_data, custom_config):
                 error_msg = f"Error: {response.get('error', 'unknown error') if isinstance(response, dict) else response or 'unknown error'}"
                 parsed_data["variables"]["web_search_pre_result"] = error_msg
 
-async def handle_post_tool(parsed_data, result):
-    """Execute the folder-level post_tool after every AI call (embed only).
-    Awaited directly; returns the post function response to allow the caller to override the AI response."""
 
+async def handle_post_tool(parsed_data, result):
+    """Execute the folder-level post_tool after every AI call."""
     post_tool_data = parsed_data.get("post_tool_data")
     if not post_tool_data:
         return
-
 
     script_id = post_tool_data.get("script_id") or post_tool_data.get("function_name") or post_tool_data.get("endpoint_name")
     if not script_id:
@@ -534,7 +532,23 @@ async def handle_post_tool(parsed_data, result):
         )
     except Exception as err:
         logger.error(f"post_tool execution error (script_id={script_id}): {err}")
-    return post_tool_response
+        return
+
+    flow_hit_id = (post_tool_response.get("metadata") or {}).get("flowHitId")
+    entry = {
+        "id": post_tool_data.get("script_id"),
+        "args": post_tool_data.get("args", {}),
+        "data": post_tool_response,
+        "type": "post_tool",
+        "name": post_tool_data.get("title") or post_tool_data.get("script_id"),
+        "error": post_tool_response.get("status") != 1,
+    }
+    post_tool_log = {flow_hit_id: entry} if flow_hit_id else entry
+    if result is not None and result.get("historyParams") is not None:
+        result["historyParams"].setdefault("tools_call_data", []).append(post_tool_log)
+    if post_tool_response.get("status") == 1 and post_tool_response.get("response") is not None:
+        if isinstance(result, dict) and result.get("response", {}).get("data") is not None:
+            result["response"]["data"]["content"] = post_tool_response.get("response")
 
 async def manage_threads(parsed_data):
     thread_id = parsed_data["thread_id"]
@@ -1765,26 +1779,7 @@ async def sse_stream_and_finalize(class_obj, parsed_data, params, timer, thread_
         model_response = result.get("modelResponse", {}) if isinstance(result, dict) else {}
         formatted_response = result.get("response", {}) if isinstance(result, dict) else {}
 
-        post_tool_response = await handle_post_tool(parsed_data, result)
-        if post_tool_response is not None:
-            post_tool_data = parsed_data.get("post_tool_data", {})
-            flow_hit_id = (post_tool_response.get("metadata") or {}).get("flowHitId")
-            entry = {
-                "id": post_tool_data.get("script_id"),
-                "args": post_tool_data.get("args", {}),
-                "data": post_tool_response,
-                "type": "post_tool",
-                "name": post_tool_data.get("title") or post_tool_data.get("script_id"),
-                "error": post_tool_response.get("status") != 1,
-            }
-            post_tool_log = {flow_hit_id: entry} if flow_hit_id else entry
-            if result.get("historyParams") is not None:
-                result["historyParams"].setdefault("tools_call_data", []).append(post_tool_log)
-            if post_tool_response.get("status") == 1 and post_tool_response.get("response") is not None:
-                if formatted_response.get("data") is not None:
-                    formatted_response["data"]["content"] = post_tool_response.get("response")
-                if result.get("response", {}).get("data") is not None:
-                    result["response"]["data"]["content"] = post_tool_response.get("response")
+        await handle_post_tool(parsed_data, result)
 
         if not parsed_data["is_playground"]:
             await sendResponse(

--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -1762,6 +1762,30 @@ async def sse_stream_and_finalize(class_obj, parsed_data, params, timer, thread_
             result.setdefault("response", {}).setdefault("usage", {})
             result["response"]["usage"]["cost"] = parsed_data["usage"].get("expectedCost", 0)
 
+        model_response = result.get("modelResponse", {}) if isinstance(result, dict) else {}
+        formatted_response = result.get("response", {}) if isinstance(result, dict) else {}
+
+        post_tool_response = await handle_post_tool(parsed_data, result)
+        if post_tool_response is not None:
+            post_tool_data = parsed_data.get("post_tool_data", {})
+            flow_hit_id = (post_tool_response.get("metadata") or {}).get("flowHitId")
+            entry = {
+                "id": post_tool_data.get("script_id"),
+                "args": post_tool_data.get("args", {}),
+                "data": post_tool_response,
+                "type": "post_tool",
+                "name": post_tool_data.get("title") or post_tool_data.get("script_id"),
+                "error": post_tool_response.get("status") != 1,
+            }
+            post_tool_log = {flow_hit_id: entry} if flow_hit_id else entry
+            if result.get("historyParams") is not None:
+                result["historyParams"].setdefault("tools_call_data", []).append(post_tool_log)
+            if post_tool_response.get("status") == 1 and post_tool_response.get("response") is not None:
+                if formatted_response.get("data") is not None:
+                    formatted_response["data"]["content"] = post_tool_response.get("response")
+                if result.get("response", {}).get("data") is not None:
+                    result["response"]["data"]["content"] = post_tool_response.get("response")
+
         if not parsed_data["is_playground"]:
             await sendResponse(
                 parsed_data.get("response_format"),
@@ -1776,8 +1800,6 @@ async def sse_stream_and_finalize(class_obj, parsed_data, params, timer, thread_
             await process_background_tasks_for_playground(result, parsed_data)
 
         if class_obj.streamer:
-            model_response = result.get("modelResponse", {}) if isinstance(result, dict) else {}
-            formatted_response = result.get("response", {}) if isinstance(result, dict) else {}
             if getattr(class_obj, 'tool_call_limit_error', None):
                 result["error"] = class_obj.tool_call_limit_error
             if result.get("error"):
@@ -1788,12 +1810,6 @@ async def sse_stream_and_finalize(class_obj, parsed_data, params, timer, thread_
                 or model_response.get("status")
                 or ""
             )
-            post_tool_response = await handle_post_tool(parsed_data, result)
-            if post_tool_response and post_tool_response.get("status") == 1 and post_tool_response.get("response") is not None:
-                if formatted_response.get("data") is not None:
-                    formatted_response["data"]["content"] = post_tool_response.get("response")
-                if result.get("response", {}).get("data") is not None:
-                    result["response"]["data"]["content"] = post_tool_response.get("response")
             if not is_nested_stream_call:
                 accumulated_payload = None if template_data else formatted_response
                 await class_obj.streamer.emit_done(

--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -528,13 +528,13 @@ async def handle_post_tool(parsed_data, result):
         if response_data:
             args["ai_response"] = response_data.get("content") or response_data
 
-        post_function_response = await axios_work(
+        post_tool_response = await axios_work(
             args,
             {"url": f"https://flow.sokt.io/func/{script_id}"},
         )
     except Exception as err:
         logger.error(f"post_tool execution error (script_id={script_id}): {err}")
-    return post_function_response
+    return post_tool_response
 
 async def manage_threads(parsed_data):
     thread_id = parsed_data["thread_id"]


### PR DESCRIPTION
…t is sent to client

Relocated the `handle_post_tool` call and content update logic to execute before `sendResponse` instead of after the playground check. This ensures that any modifications made by post-tools are included in the response sent to the client. Also renamed `post_function_response` to `post_tool_response` for consistency and added `post_tool_response` to `historyParams` for tracking.