### PR TITLE
feat: add structured pre_tool_data entry with variables_path mapping …

### DIFF
--- a/src/db_services/ConfigurationServices.py
+++ b/src/db_services/ConfigurationServices.py
@@ -821,8 +821,19 @@ async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None)
                 
                 # Add folder pre_tool if not already present
                 if folder_pre_tool_id and folder_pre_tool_id not in bridge_data["pre_tools"]:
-                    bridge_data["pre_tools"].append(folder_pre_tool_id)
+                    # Build pre_tools_data with variables_path mapping
+                    script_id = folder_pre_tool.get("script_id")
+                    variables_path_pre_tool = folder_result[0].get("variables_path", {}).get(script_id, {}) if script_id else {}
+                    pre_tool_data_entry = {
+                        "type": 'custom_function',
+                        "config":{
+                            "function_id": folder_pre_tool_id,
+                            "script_id": script_id
+                        },
+                        "args": variables_path_pre_tool or folder_pre_tool.get("args", {}),
+                    }
                     bridge_data["pre_tools_data"].append(folder_pre_tool)
+                    bridge_data["pre_tools"].append(pre_tool_data_entry)
 
             # Merge folder_post_tool into bridge_data
             if folder_result and folder_result[0].get("folder_post_tool"):


### PR DESCRIPTION
…for folder pre_tools

- Modified folder pre_tool handling to build a structured pre_tool_data_entry with type, config (function_id, script_id), and args
- Added variables_path mapping from folder_result to pre_tool args, falling back to folder_pre_tool args if not present
- Changed bridge_data["pre_tools"].append() to use the structured pre_tool_data_entry instead of just folder_pre_tool_id
- Maintained backward compatibility by