### PR TITLE
feat: update public agent access to use org-scoped slug names and new…

### DIFF
--- a/src/db_services/ConfigurationServices.py
+++ b/src/db_services/ConfigurationServices.py
@@ -968,16 +968,17 @@ async def update_bridge(bridge_id=None, update_fields=None, version_id=None, org
     return {"success": True, "result": updated_bridge}
 
 
-async def get_agents_data(slug_name, user_email):
+async def get_agents_data(slug_name, user_email, org_id):
     bridges = await configurationModel.find_one(
         {
             "$or": [
-                {"$and": [{"page_config.availability": "public"}, {"page_config.url_slugname": slug_name}]},
+                {"$and": [{"settings.publicAgentConfig.availability": "public"}, {"slugName": slug_name}, {"org_id": org_id}]},
                 {
                     "$and": [
-                        {"page_config.availability": "private"},
-                        {"page_config.url_slugname": slug_name},
-                        {"page_config.allowedUsers": user_email},
+                        {"settings.publicAgentConfig.availability": "private"},
+                        {"slugName": slug_name},
+                        {"settings.publicAgentConfig.allowedUsers": user_email},
+                        {"org_id": org_id},
                     ]
                 },
             ]

--- a/src/middlewares/interfaceMiddlewares.py
+++ b/src/middlewares/interfaceMiddlewares.py
@@ -16,7 +16,6 @@ from .getDataUsingBridgeId import add_configuration_data_to_body
 
 async def send_data_middleware(request: Request, botId: str, body: ChatbotSendMessageRequest):
     try:
-        org_id = request.state.profile["org"]["id"]
         slugName = body.slugName
         isPublic = "ispublic" in request.state.profile
         user_email = (
@@ -24,6 +23,14 @@ async def send_data_middleware(request: Request, botId: str, body: ChatbotSendMe
             if isPublic
             else request.state.profile.get("user", {}).get("email", "")
         )
+        
+        # For public users, extract org_id and slugName from combined format (orgId::slugName)
+        if isPublic and "::" in slugName:
+            org_id, slugName = slugName.split("::", 1)
+            request.state.profile["org"]["id"] = org_id
+
+        org_id = request.state.profile["org"]["id"]
+        
         if isPublic and "user" in request.state.profile:
             threadId = str(request.state.profile["user"]["id"])
         else:
@@ -39,8 +46,8 @@ async def send_data_middleware(request: Request, botId: str, body: ChatbotSendMe
         channelId = f"{chatBotId}{threadId.strip() if threadId and threadId.strip() else userId}{subThreadId.strip() if subThreadId and subThreadId.strip() else userId}"
         channelId = channelId.replace(" ", "_")
         if isPublic:
-            bridge_response = await ConfigurationServices.get_agents_data(slugName, user_email)
-            org = {"id": bridge_response.get("org_id")}
+            bridge_response = await ConfigurationServices.get_agents_data(slugName, user_email, org_id)
+            org = {"id": bridge_response.get("org_id") or org_id}
             request.state.profile["org"] = org
         else:
             bridge_response = await ConfigurationServices.get_bridge_by_slugname(org_id, slugName)


### PR DESCRIPTION
… settings structure

- Modified get_agents_data to accept org_id parameter and query using settings.publicAgentConfig instead of page_config
- Updated slugName field query from page_config.url_slugname to slugName with org_id filter
- Added org_id scoping to both public and private agent availability checks
- Implemented orgId::slugName format parsing for public users in send_data_middleware
- Extract and set org_id from combined slug