### PR TITLE
refactor: update testcase handling to support multiple IDs

### DIFF
--- a/src/services/testcase_service.py
+++ b/src/services/testcase_service.py
@@ -52,7 +52,7 @@ def validate_testcase_request_data(body: dict[str, Any]) -> dict[str, Any]:
         raise TestcaseValidationError("version_id is required")
 
     bridge_id = body.get("bridge_id")
-    testcase_id = body.get("testcase_id")
+    testcase_ids = body.get("testcase_ids")
     testcases_flag = body.get("testcases", False)
     testcase_data = body.get("testcase_data")
     variables = body.get("variables", {})
@@ -61,7 +61,7 @@ def validate_testcase_request_data(body: dict[str, Any]) -> dict[str, Any]:
     return {
         "bridge_id": bridge_id,
         "version_id": version_id,
-        "testcase_id": testcase_id,
+        "testcase_ids": testcase_ids,
         "testcases_flag": testcases_flag,
         "testcase_data": testcase_data,
         "variables": variables,
@@ -87,7 +87,7 @@ def validate_direct_testcase_data(testcase_data: dict[str, Any]) -> None:
 
 
 async def fetch_testcases_from_request(
-    testcases_flag: bool, testcase_data: dict[str, Any] | None, bridge_id: str | None, testcase_id: str | None
+    testcases_flag: bool, testcase_data: dict[str, Any] | None, bridge_id: str | None, testcase_ids: list[str] | None = None
 ) -> list[dict[str, Any]]:
     """
     Fetch testcases either from direct input or MongoDB
@@ -128,12 +128,13 @@ async def fetch_testcases_from_request(
 
         testcases_collection = db["testcases"]
 
-        if testcase_id:
-            # Fetch specific testcase by ID
-            testcase = await testcases_collection.find_one({"_id": ObjectId(testcase_id)})
-            if not testcase:
-                raise TestcaseNotFoundError("No testcase found for the given testcase_id")
-            return [testcase]
+        if testcase_ids:
+            # Fetch multiple testcases by list of IDs
+            object_ids = [ObjectId(tid) for tid in testcase_ids]
+            testcases = await testcases_collection.find({"_id": {"$in": object_ids}}).to_list(length=None)
+            if not testcases:
+                raise TestcaseNotFoundError("No testcases found for the given testcase_ids")
+            return testcases
         else:
             # Fetch all testcases for bridge_id
             testcases = await testcases_collection.find({"bridge_id": bridge_id}).to_list(length=None)
@@ -203,6 +204,10 @@ async def process_single_testcase(testcase: dict[str, Any], db_config: dict[str,
         # Deep copy the configuration to avoid race conditions in parallel execution
         if "configuration" in db_config:
             db_config["configuration"] = db_config["configuration"].copy()
+
+        # Merge testcase-stored variables (higher priority) with config/request variables
+        merged_variables = {**db_config.get("variables", {}), **testcase.get("variables", {})}
+        db_config["variables"] = merged_variables
 
         # Set conversation in db_config
         db_config["configuration"]["conversation"] = testcase.get("conversation", [])
@@ -303,7 +308,7 @@ async def execute_testcases(body: dict[str, Any], org_id: str) -> dict[str, Any]
         request_data["testcases_flag"],
         request_data["testcase_data"],
         request_data["bridge_id"],
-        request_data["testcase_id"],
+        request_data["testcase_ids"],
     )
 
     # Get configuration


### PR DESCRIPTION
- Changed `testcase_id` to `testcase_ids` in `validate_testcase_request_data` and `fetch_testcases_from_request` to allow for multiple testcases to be processed.
- Updated logic in `fetch_testcases_from_request` to fetch multiple testcases based on a list of IDs.
- Merged testcase-stored variables with configuration/request variables for improved handling.

This refactor enhances the flexibility of testcase management in the service.