### PR TITLE
fix: update response_type template extraction to use nested value str…

### DIFF
--- a/src/db_services/ConfigurationServices.py
+++ b/src/db_services/ConfigurationServices.py
@@ -451,31 +451,38 @@ async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None)
                 }
             },
              # Stage 9.5: Extract template_ids from configuration.response_type if is_template is true
+            # Handles both old structure (is_template at root) and new structure (is_template in value)
             {
                 "$addFields": {
                     "template_ids_to_fetch": {
                         "$cond": [
                             {
-                                "$and": [
-                                    {"$eq": [{"$type": "$configuration.response_type"}, "object"]},
-                                    {"$eq": ["$configuration.response_type.is_template", True]},
-                                    {"$isArray": "$configuration.response_type.template_id"},
-                                    {"$gt": [{"$size": "$configuration.response_type.template_id"}, 0]},
-                                ]
+                               
+                                {
+                                    "$and": [
+                                        {"$eq": [{"$type": "$configuration.response_type"}, "object"]},
+                                        {"$eq": ["$configuration.response_type.value.is_template", True]},
+                                        {"$isArray": "$configuration.response_type.value.template_id"},
+                                        {"$gt": [{"$size": "$configuration.response_type.value.template_id"}, 0]},
+                                    ]
+                                },                                
                             },
                             {
-                                "$map": {
-                                    "input": "$configuration.response_type.template_id",
-                                    "as": "tid",
-                                    "in": {
-                                        "$convert": {
-                                            "input": "$$tid",
-                                            "to": "objectId",
-                                            "onError": None,
-                                            "onNull": None,
-                                        }
-                                    },
-                                }
+                            
+                                {
+                                    "$map": {
+                                        "input": "$configuration.response_type.value.template_id",
+                                        "as": "tid",
+                                        "in": {
+                                            "$convert": {
+                                                "input": "$$tid",
+                                                "to": "objectId",
+                                                "onError": None,
+                                                "onNull": None,
+                                            }
+                                        },
+                                    }
+                                },
                             },
                             [],
                         ]

--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -45,7 +45,7 @@ def setup_agent_tools(parsed_data, bridge_configurations, tool_data):
     agent_variables = parsed_data.get("variables", {})
 
     def resolve_args(tool_config, tool_args_mapping, is_custom=False):
-        resolved = dict(tool_config)
+        resolved = {}
         for param, var_name in tool_args_mapping.items():
             if var_name in agent_variables:
                 resolved[param] = agent_variables[var_name]


### PR DESCRIPTION
…ucture

- Modified template_ids_to_fetch extraction to access is_template and template_id from configuration.response_type.value path instead of root level
- Updated aggregation pipeline to support new nested response_type structure
- Fixed resolve_args in setup_agent_tools to initialize empty dict instead of copying tool_config to prevent unintended parameter inheritance