### PR TITLE
fix: enhance tool choice configuration handling in setup_tool_choice

### DIFF
--- a/src/services/utils/getConfiguration_utils.py
+++ b/src/services/utils/getConfiguration_utils.py
@@ -62,6 +62,12 @@ def setup_configuration(configuration, bridges, service):
 def setup_tool_choice(configuration, bridges, service):
     """Setup tool choice configuration"""
     tool_choice_ids = configuration.get("tool_choice", "")
+
+    # If caller already provided a fully-formed tool_choice (dict/list), pass it through
+    # unchanged — the lookup logic below only makes sense for a string ID.
+    if not isinstance(tool_choice_ids, str):
+        return tool_choice_ids
+
     toolchoice = None
 
     # Find tool choice from API calls


### PR DESCRIPTION
- Added a check to return the tool_choice_ids unchanged if it is already a fully-formed dict/list, ensuring the lookup logic only applies to string IDs.
- This change improves the robustness of the setup_tool_choice function by preventing unnecessary processing of non-string tool choices.