### PR TITLE
fix: apply frontend transformation before tool_choice setup in getCon…

### DIFF
--- a/src/services/utils/getConfiguration.py
+++ b/src/services/utils/getConfiguration.py
@@ -95,6 +95,10 @@ async def _prepare_configuration_response(
 
     service = service.lower() if service else ""
 
+    config_with_service = {"configuration": configuration, "service": service}
+    transformed = transform_agent_config_to_frontend(config_with_service)
+    configuration = transformed.get("configuration", configuration)
+
     # Initialize apikey_status with default value
     apikey_status = {}
 


### PR DESCRIPTION
…figuration

- Moved transform_agent_config_to_frontend call before tool_choice initialization to ensure configuration is properly transformed
- Ensures advanced parameters are in correct frontend format before further processing
- Maintains service context during transformation