### PR TITLE
fix: increased the aio buffer size for openai image chinks

### DIFF
--- a/src/services/utils/apiservice.py
+++ b/src/services/utils/apiservice.py
@@ -30,7 +30,10 @@ async def fetch_stream(url, method="POST", headers=None, json_body=None):
     """Async generator that yields raw SSE lines from a streaming HTTP response."""
     ssl_context = ssl.create_default_context(cafile=certifi.where())
 
-    async with aiohttp.ClientSession() as session:
+    # 10 MiB buffer — large enough for SSE lines that embed base64 payloads
+    # (e.g. OpenAI ``response.image_generation_call.partial_image``), which
+    # exceed aiohttp's default ~128 KB per-line limit.
+    async with aiohttp.ClientSession(read_bufsize=64 * 1024 * 1024) as session:
         async with session.request(
             method=method, url=url, headers=headers, json=json_body, ssl=ssl_context
         ) as response:


### PR DESCRIPTION
### Fix: increase aiohttp read buffer for OpenAI image streaming

OpenAI's `response.image_generation_call.partial_image` events put a base64 image on one SSE line, exceeding aiohttp's default ~128 KB per-line limit and crashing the stream with `Got more than 131072 bytes when reading`.

Bumped `read_bufsize` on `ClientSession` to **64 MiB** in [fetch_stream](cci:1://file:///c:/Users/adity/Documents/gtwy-python/fastapi/AI-middleware-python/src/services/utils/apiservice.py:28:0-45:33) — enough to cover OpenAI's max documented image size (`3840 × 2160`). The buffer is a cap, not a pre-allocation, so there's no impact on normal small-event streams.