### PR TITLE
refactor: update testcase retrieval logic in controllers and services

### DIFF
--- a/src/controllers/testcase_controller.py
+++ b/src/controllers/testcase_controller.py
@@ -5,7 +5,7 @@ from fastapi.responses import JSONResponse
 from src.db_services.testcase_services import (
     create_testcase,
     delete_testcase_by_id,
-    get_merged_testcases_and_history_by_bridge_id,
+    get_all_testcases_by_bridge_id,
     get_testcase_by_id,
     update_testcase_by_id,
 )
@@ -53,23 +53,10 @@ async def delete_testcase_controller(testcase_id):
 
 
 async def get_all_testcases_controller(bridge_id):
-    """Get all testcases with their history merged for a specific bridge_id"""
+    """Get all testcases for a specific bridge_id (run history lives in Postgres conversation_logs)"""
     try:
-        # Get merged data from both testcases and testcases_history collections
-        merged_testcases = await get_merged_testcases_and_history_by_bridge_id(bridge_id)
-
-        # Group history by version_id for each testcase
-        for testcase in merged_testcases:
-            testcase["version_history"] = {}
-            for history in testcase["history"]:
-                version_id = history["version_id"]
-                if not testcase["version_history"].get(version_id):
-                    testcase["version_history"][version_id] = []
-                testcase["version_history"][version_id].append(history)
-            # Remove the original history array as it's now organized by version_id
-            del testcase["history"]
-
-        return JSONResponse(content={"success": True, "data": make_json_serializable(merged_testcases)})
+        testcases = await get_all_testcases_by_bridge_id(bridge_id)
+        return JSONResponse(content={"success": True, "data": make_json_serializable(testcases)})
     except Exception as error:
         traceback.print_exc()
         return JSONResponse(status_code=400, content={"success": False, "error": str(error)})

--- a/src/db_services/metrics_service.py
+++ b/src/db_services/metrics_service.py
@@ -194,6 +194,8 @@ def build_history_and_metrics_payload(dataset, history_params, version_id):
         "prompt": history_params.get("prompt"),
         "is_cached": history_params.get("is_cached", False),
         "plans": history_params.get("plans"),
+        "testcase_id": history_params.get("testcase_id"),
+        "testcase_data": history_params.get("testcase_data"),
     }
 
     latency = latency_data.get("over_all_time", 0) if latency_data else 0

--- a/src/db_services/testcase_services.py
+++ b/src/db_services/testcase_services.py
@@ -1,5 +1,4 @@
 import datetime
-import traceback
 
 from bson import ObjectId
 from fastapi import HTTPException
@@ -9,7 +8,6 @@ from models.mongo_connection import db
 
 configurationModel = db["configurations"]
 testcases_model = db["testcases"]
-testcases_history_model = db["testcases_history"]
 
 
 async def get_testcases(bridge_id):
@@ -59,22 +57,6 @@ async def update_testcase_by_id(testcase_id, update_data):
         raise e
 
 
-async def get_version_updated_at(version_id):
-    """Return updatedAt for a configuration version, or None."""
-    try:
-        version_model = db["configuration_versions"]
-        doc = await version_model.find_one(
-            {"_id": ObjectId(version_id)},
-            {"updatedAt": 1},
-        )
-        if not doc:
-            return None
-        return doc.get("updatedAt")
-    except Exception as e:
-        logger.error(f"Error fetching version updatedAt: {str(e)}")
-        return None
-
-
 async def update_testcase_last_executed(testcase_ids):
     """Update execution.lastExecutedAt for the given testcase ids"""
     try:
@@ -98,57 +80,6 @@ async def update_testcase_last_executed(testcase_ids):
     except Exception as e:
         logger.error(f"Error updating testcase lastExecutedAt: {str(e)}")
         return None
-
-
-async def create_testcases_history(data):
-    result = await testcases_history_model.insert_many(data)
-    for obj in data:
-        obj["_id"] = str(obj["_id"])
-    return result
-
-
-async def get_merged_testcases_and_history_by_bridge_id(bridge_id):
-    """Get all testcases with their history merged for a specific bridge_id"""
-    try:
-        # Use aggregation pipeline to merge testcases with their history
-        pipeline = [
-            {"$match": {"bridge_id": bridge_id}},
-            {
-                "$lookup": {
-                    "from": "testcases_history",
-                    "let": {"testcaseIdStr": {"$toString": "$_id"}},
-                    "pipeline": [{"$match": {"$expr": {"$eq": ["$testcase_id", "$$testcaseIdStr"]}}}],
-                    "as": "history",
-                }
-            },
-        ]
-
-        cursor = testcases_model.aggregate(pipeline)
-        result = await cursor.to_list(length=None)
-        return result
-    except Exception as e:
-        logger.error(f"Error fetching merged testcases and history: {str(e)}")
-        raise e
-
-
-async def delete_current_testcase_history(version_id):
-    try:
-        pipeline = [
-            {"$match": {"version_id": version_id}},
-            {"$sort": {"testcase_id": 1, "created_at": -1}},
-            {"$group": {"_id": "$testcase_id", "latest_id": {"$first": "$_id"}}},
-            {"$project": {"_id": 0, "latest_id": 1}},
-        ]
-
-        # Get IDs of latest entries
-        cursor = testcases_history_model.aggregate(pipeline)
-        latest_ids = [doc["latest_id"] async for doc in cursor]
-
-        # Delete all other entries for the given version_id
-        await testcases_history_model.delete_many({"version_id": version_id, "_id": {"$nin": latest_ids}})
-    except Exception as e:
-        logger.error(f"Error in deleting current testcase history: {str(e)}")
-        traceback.print_exc()
 
 
 async def parse_and_save_testcases(testcases_data, bridge_id: str):

--- a/src/routes/v2/modelRouter.py
+++ b/src/routes/v2/modelRouter.py
@@ -109,6 +109,7 @@ async def run_testcases_route(request: Request):
 
     body = await request.json()
     org_id = request.state.profile["org"]["id"]
+    body.setdefault("state", {})["profile"] = request.state.profile
     bridge_id = body.get("bridge_id")
     if not bridge_id:
         raise HTTPException(

--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -161,6 +161,7 @@ async def chat(request_body):
     try:
         # Store bridge_configurations for potential transfer logic
         bridge_configurations = request_body.get("body", {}).get("bridge_configurations", {})
+        print("bridge_configurations\n\n\n", bridge_configurations, "\n\n\n")
         # Step 1: Parse and validate request body
         parsed_data = parse_request_body(request_body)
 
@@ -602,6 +603,23 @@ async def chat(request_body):
                 parsed_data.get("testcase_data", {}), result, parsed_data
             )
             result["response"]["testcase_result"] = testcase_result
+
+            # Stamp the testcase fields onto historyParams so the log queue
+            # persists them onto the conversation_logs row in Postgres.
+            if result.get("historyParams") is not None:
+                result["historyParams"]["testcase_id"] = testcase_result.get("testcase_id")
+                result["historyParams"]["testcase_data"] = {
+                    "expected": testcase_result.get("expected"),
+                    "actual": testcase_result.get("actual"),
+                    "score": testcase_result.get("score"),
+                    "matching_type": testcase_result.get("matching_type"),
+                    "type": testcase_result.get("type"),
+                    "success": testcase_result.get("success"),
+                    "error": testcase_result.get("error"),
+                    "system_prompt": parsed_data.get("configuration", {}).get("prompt", ""),
+                    "model": parsed_data.get("configuration", {}).get("model", ""),
+                }
+
             if parsed_data.get("body", {}).get("bridge_configurations", {}).get("playground_response_format"):
                 await sendResponse(
                     parsed_data["body"]["bridge_configurations"]["playground_response_format"],

--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -161,7 +161,6 @@ async def chat(request_body):
     try:
         # Store bridge_configurations for potential transfer logic
         bridge_configurations = request_body.get("body", {}).get("bridge_configurations", {})
-        print("bridge_configurations\n\n\n", bridge_configurations, "\n\n\n")
         # Step 1: Parse and validate request body
         parsed_data = parse_request_body(request_body)
 

--- a/src/services/commonServices/testcases.py
+++ b/src/services/commonServices/testcases.py
@@ -1,10 +1,7 @@
-from datetime import datetime
-
 import pydash as _
 
 from globals import logger
 from src.configs.constant import bridge_ids
-from src.db_services.testcase_services import create_testcases_history
 from src.services.utils.ai_call_util import call_ai_middleware
 from src.services.utils.nlp import compute_cosine_similarity
 
@@ -29,43 +26,25 @@ async def compare_result(expected, actual, matching_type, response_type):
 
 async def process_single_testcase_result(testcase_data, model_result, parsed_data):
     """
-    Process a single testcase result: calculate score and save to history
+    Score a single testcase result. The score + metadata are returned so the
+    caller can attach them to historyParams and let the log queue persist them
+    onto the conversation_logs row in Postgres.
     """
     try:
-        # Extract the actual response from model result
         actual_result = (
             model_result.get("response", {}).get("data", {}).get("content", "")
             if isinstance(model_result, dict)
             else str(model_result)
         )
 
-        # Get expected result based on testcase type
         expected_result = testcase_data.get("expected", {}).get(
             "response" if testcase_data.get("type") == "response" else "tool_calls", ""
         )
 
-        # Calculate score using the matching type
         matching_type = testcase_data.get("matching_type", "cosine")
         testcase_type = testcase_data.get("type", "response")
 
         score = await compare_result(expected_result, actual_result, matching_type, testcase_type)
-
-        # Prepare data for saving to history
-        data_to_insert = {
-            "bridge_id": parsed_data.get("bridge_id"),
-            "version_id": parsed_data.get("version_id"),
-            "created_at": datetime.now().isoformat(),
-            "testcase_id": str(testcase_data.get("_id")),
-            "metadata": {
-                "system_prompt": parsed_data.get("configuration", {}).get("prompt", ""),
-                "model": parsed_data.get("configuration", {}).get("model", ""),
-            },
-            "model_output": actual_result,
-            "score": score,
-        }
-
-        # Save to testcase history
-        await create_testcases_history([data_to_insert])
 
         return {
             "testcase_id": str(testcase_data.get("_id")),
@@ -73,6 +52,7 @@ async def process_single_testcase_result(testcase_data, model_result, parsed_dat
             "actual": actual_result,
             "score": score,
             "matching_type": matching_type,
+            "type": testcase_type,
             "success": True,
         }
 

--- a/src/services/testcase_service.py
+++ b/src/services/testcase_service.py
@@ -341,95 +341,37 @@ async def process_single_testcase(
         return outcome
 
 
-def _filter_testcases_to_run(
-    testcases: list[dict[str, Any]],
-    version_updated_at,
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """Split testcases into (to_run, skipped) based on lastExecutedAt vs updatedAt.
-
-    Skip when both version.updatedAt <= lastExecutedAt and
-    testcase.updatedAt <= lastExecutedAt.
-    """
-    if not version_updated_at:
-        return testcases, []
-
-    to_run: list[dict[str, Any]] = []
-    skipped: list[dict[str, Any]] = []
-    for tc in testcases:
-        tc_updated_at = tc.get("updatedAt") or tc.get("updated_at")
-        execution = tc.get("execution") or {}
-        last_executed_at = execution.get("lastExecutedAt")
-
-        if (
-            last_executed_at
-            and tc_updated_at
-            and version_updated_at <= last_executed_at
-            and tc_updated_at <= last_executed_at
-        ):
-            # Use same shape as executed results so the frontend can render uniformly.
-            # Coerce datetime/ObjectId to JSON-safe strings for RTLayer publish.
-            skipped.append({
-                "testcase_id": str(tc.get("_id")),
-                "bridge_id": str(tc.get("bridge_id")) if tc.get("bridge_id") else None,
-                "expected": tc.get("expected"),
-                "actual_result": None,
-                "score": None,
-                "matching_type": tc.get("matching_type", "cosine"),
-                "success": True,
-                "skipped": True,
-                "reason": "no_changes_since_last_execution",
-                "last_executed_at": last_executed_at.isoformat() if hasattr(last_executed_at, "isoformat") else str(last_executed_at),
-            })
-        else:
-            to_run.append(tc)
-    return to_run, skipped
-
-
 async def run_testcases_parallel(
     testcases: list[dict[str, Any]],
     db_config: dict[str, Any],
     override_matching_type: str | None,
-    version_updated_at=None,
     rtlayer_cred: dict[str, Any] | None = None,
     version_id: str | None = None,
 ) -> list[dict[str, Any]]:
     """
-    Run multiple testcases in parallel
+    Run multiple testcases in parallel.
 
     Args:
         testcases: List of testcase dictionaries
         db_config: Configuration dictionary
         override_matching_type: Optional override matching type
-        version_updated_at: Optional version updatedAt timestamp (for skip logic)
         rtlayer_cred: Optional RTLayer credentials for streaming results
         version_id: Version id, included in published payloads
 
     Returns:
-        List of testcase results (executed + skipped)
+        List of testcase results
     """
-    # Filter out testcases that don't need rerun (version & testcase unchanged)
-    to_run, skipped = _filter_testcases_to_run(testcases, version_updated_at)
-
-    # Notify skipped testcases up-front so the client can render them immediately
-    if skipped:
-        await asyncio.gather(*[
-            _publish_event(rtlayer_cred, "testcase_result", {"version_id": version_id, "result": s})
-            for s in skipped
-        ])
-
-    # Process pending testcases in parallel
     results = await asyncio.gather(
         *[
             process_single_testcase(tc, db_config.copy(), override_matching_type, rtlayer_cred, version_id)
-            for tc in to_run
+            for tc in testcases
         ]
     )
 
-    # Update execution.lastExecutedAt for all executed testcases (skip direct_testcase)
     try:
         from src.db_services.testcase_services import update_testcase_last_executed
         executed_ids = [
-            tc.get("_id") for tc in to_run
+            tc.get("_id") for tc in testcases
             if tc.get("_id") and tc.get("_id") != "direct_testcase"
         ]
         if executed_ids:
@@ -437,7 +379,7 @@ async def run_testcases_parallel(
     except Exception as e:
         logger.error(f"Failed to update lastExecutedAt: {str(e)}")
 
-    return results + skipped
+    return results
 
 
 async def execute_testcases(
@@ -461,8 +403,6 @@ async def execute_testcases(
         TestcaseValidationError: If validation fails
         TestcaseNotFoundError: If testcases are not found
     """
-    from src.db_services.testcase_services import get_version_updated_at
-
     # Validate request data
     request_data = validate_testcase_request_data(body)
 
@@ -487,22 +427,18 @@ async def execute_testcases(
     )
 
     async def run_for_version(version_id):
-        db_config, version_updated_at = await asyncio.gather(
-            get_testcase_configuration(
-                org_id,
-                version_id,
-                request_data["bridge_id"],
-                request_data["testcases_flag"],
-                request_data["testcase_data"],
-                request_data["variables"],
-            ),
-            get_version_updated_at(version_id),
+        db_config = await get_testcase_configuration(
+            org_id,
+            version_id,
+            request_data["bridge_id"],
+            request_data["testcases_flag"],
+            request_data["testcase_data"],
+            request_data["variables"],
         )
         results = await run_testcases_parallel(
             testcases,
             db_config,
             request_data["matching_type"],
-            version_updated_at=version_updated_at,
             rtlayer_cred=rtlayer_cred,
             version_id=version_id,
         )
@@ -514,7 +450,7 @@ async def execute_testcases(
 
     # Run all versions concurrently (works for 1 or N)
     version_results = await asyncio.gather(*[run_for_version(vid) for vid in version_ids])
-
+    print("version_results\n\n\n", version_results, "\n\n\n")
     final_payload = {
         "success": True,
         "bridge_id": request_data["bridge_id"],

--- a/src/services/testcase_service.py
+++ b/src/services/testcase_service.py
@@ -9,6 +9,7 @@ This module provides functions for handling testcase operations including:
 """
 
 import asyncio
+import copy
 import json
 import logging
 from typing import Any
@@ -243,10 +244,6 @@ async def process_single_testcase(
         Dictionary containing testcase result
     """
     try:
-        # Deep copy the configuration to avoid race conditions in parallel execution
-        if "configuration" in db_config:
-            db_config["configuration"] = db_config["configuration"].copy()
-
         # Merge testcase-stored variables (higher priority) with config/request variables
         merged_variables = {**db_config.get("variables", {}), **testcase.get("variables", {})}
         db_config["variables"] = merged_variables
@@ -363,7 +360,7 @@ async def run_testcases_parallel(
     """
     results = await asyncio.gather(
         *[
-            process_single_testcase(tc, db_config.copy(), override_matching_type, rtlayer_cred, version_id)
+            process_single_testcase(tc, copy.deepcopy(db_config), override_matching_type, rtlayer_cred, version_id)
             for tc in testcases
         ]
     )
@@ -450,7 +447,6 @@ async def execute_testcases(
 
     # Run all versions concurrently (works for 1 or N)
     version_results = await asyncio.gather(*[run_for_version(vid) for vid in version_ids])
-    print("version_results\n\n\n", version_results, "\n\n\n")
     final_payload = {
         "success": True,
         "bridge_id": request_data["bridge_id"],


### PR DESCRIPTION
- Replaced the merged testcase retrieval method with a direct call to get_all_testcases_by_bridge_id for improved clarity and performance.
- Removed unused create_testcases_history function and related history management logic from testcase_services.
- Enhanced the processing of testcase results to include additional metadata for logging purposes.
- Updated comments and documentation to reflect changes in functionality and improve understanding.