### PR TITLE
refactor: disable streaming for template mode and simplify latency ha…

### DIFF
--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -50,8 +50,6 @@ def setup_agent_tools(parsed_data, bridge_configurations, tool_data):
         for param, var_name in tool_args_mapping.items():
             if var_name in agent_variables:
                 resolved[param] = agent_variables[var_name]
-            elif not is_custom:
-                resolved[param] = var_name
         for param in tool_config.get("required", []):
             if param not in resolved and param in agent_variables:
                 resolved[param] = agent_variables[param]


### PR DESCRIPTION
…ndling

- Added is_template_mode check to disable streaming when template is requested, forcing RTLayer usage instead
- Replaced manual latency object construction with create_latency_object utility function call
- Fixed tool argument resolution to set empty string for unresolved parameters instead of using variable name
- Minor formatting adjustment in save_error_history call indentation