### PR TITLE
feat: add environment-based version resolution to bridge configuration

### DIFF
--- a/src/db_services/ConfigurationServices.py
+++ b/src/db_services/ConfigurationServices.py
@@ -113,9 +113,14 @@ async def get_bridges_without_tools(bridge_id=None, org_id=None, version_id=None
         raise error
 
 
-async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None):
+async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None, environment=None):
     try:
-        cache_key = f"{redis_keys['bridge_data_with_tools_']}{org_id}_{version_id or bridge_id}"
+        use_env_resolution = bool(environment and not version_id)
+
+        cache_suffix = f"{org_id}_{version_id or bridge_id}"
+        if use_env_resolution:
+            cache_suffix += f"_env_{environment}"
+        cache_key = f"{redis_keys['bridge_data_with_tools_']}{cache_suffix}"
 
         # Attempt to retrieve data from Redis cache
         cached_data = await find_in_cache(cache_key)
@@ -128,7 +133,63 @@ async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None)
             # Stage 0: Match the specific bridge or version with the given org_id
             {"$match": {"_id": ObjectId(id_to_use), "org_id": org_id}},
             {"$project": {"configuration.encoded_prompt": 0}},
-            # Stage 1: Lookup to join with 'apicalls' collection
+            # --- Environment-based version resolution ---
+            # Resolve version_id from settings.environment_config and swap to
+            # the version document. If environment key is missing, continue
+            # with the agent document as-is.
+            *([{
+                "$addFields": {
+                    "_env_resolved_version_oid": {
+                        "$convert": {
+                            "input": f"$settings.environment_config.{environment}",
+                            "to": "objectId",
+                            "onError": None,
+                            "onNull": None,
+                        }
+                    }
+                }
+            },
+            {
+                "$lookup": {
+                    "from": "configuration_versions",
+                    "let": {"version_oid": "$_env_resolved_version_oid"},
+                    "pipeline": [
+                        {
+                            "$match": {
+                                "$expr": {
+                                    "$and": [
+                                        {"$ne": ["$$version_oid", None]},
+                                        {"$eq": ["$_id", "$$version_oid"]},
+                                    ]
+                                }
+                            }
+                        },
+                        {"$project": {"configuration.encoded_prompt": 0}},
+                    ],
+                    "as": "_env_version_docs",
+                }
+            },
+            # If version doc found → swap root to it (preserving parent_id).
+            # Otherwise keep original agent doc unchanged.
+            {
+                "$replaceRoot": {
+                    "newRoot": {
+                        "$cond": [
+                            {"$gt": [{"$size": "$_env_version_docs"}, 0]},
+                            {
+                                "$mergeObjects": [
+                                    {"$arrayElemAt": ["$_env_version_docs", 0]},
+                                    {
+                                        "parent_id": {"$toString": "$_id"},
+                                        "_env_resolved": True,
+                                    }
+                                ]
+                            },
+                            "$$ROOT"
+                        ]
+                    }
+                }
+            }] if use_env_resolution else []),
             {"$lookup": {"from": "apicalls", "localField": "function_ids", "foreignField": "_id", "as": "apiCalls"}},
             # Stage 2: Restructure fields for _id, function_ids and apiCalls
             {
@@ -504,9 +565,10 @@ async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None)
                     }
                 }
             },
-            # Stage A (version only): Convert parent_id string → ObjectId for $lookup.
-            # Runs whenever version_id is provided — bridge-level fields like bridgeType
-            # live on the bridge doc, not the version doc, so we must always enrich.
+            # Stage A: Convert parent_id string → ObjectId for $lookup.
+            # Runs when version_id is provided or environment resolved to a version —
+            # bridge-level fields like bridgeType live on the bridge doc, not the
+            # version doc, so we must always enrich.
             *([{
                 "$addFields": {
                     "parent_bridge_oid": {
@@ -519,7 +581,7 @@ async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None)
                     }
                 }
             },
-            # Stage B (version only): Lookup the parent bridge doc from configurations
+            # Stage B: Lookup the parent bridge doc from configurations
             {
                 "$lookup": {
                     "from": "configurations",
@@ -540,8 +602,6 @@ async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None)
                     "as": "parent_bridge_docs",
                 }
             },
-            # Stage C (version only): Pull only bridge-level fields from parent doc into version doc.
-            # Uses $ifNull so version-level value wins if already set; parent fills only when absent.
             {
                 "$addFields": {
                     "bridge_status": {
@@ -569,7 +629,7 @@ async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None)
                         "$ifNull": ["$bridge_limit_reset_period", {"$arrayElemAt": ["$parent_bridge_docs.bridge_limit_reset_period", 0]}]
                     },
                 }
-            }] if version_id else []),
+            }] if version_id or use_env_resolution else []),
             # Stage 10: Remove temporary fields to clean up the output
             {
                 "$project": {
@@ -582,10 +642,8 @@ async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None)
                     "template_ids_to_fetch": 0,
                     "templates_docs": 0,
                     "agent_names_docs": 0,
-                    **({
-                        "parent_bridge_oid": 0,
-                        "parent_bridge_docs": 0,
-                    } if version_id else {}),
+                    **({"parent_bridge_oid": 0, "parent_bridge_docs": 0} if version_id or use_env_resolution else {}),
+                    **({"_env_resolved_version_oid": 0, "_env_version_docs": 0, "_env_resolved": 0} if use_env_resolution else {}),
                 }
             },
         ]
@@ -1020,7 +1078,7 @@ async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None)
 
         # Structure the final response
         response = {"success": True, "bridges": bridge_data}
-        tags = extract_cache_tags(response)
+        tags = extract_cache_tags(response, environment)
         await store_in_cache_with_tags(cache_key, response, tags)
         return response
 

--- a/src/middlewares/getDataUsingBridgeId.py
+++ b/src/middlewares/getDataUsingBridgeId.py
@@ -38,7 +38,8 @@ async def add_configuration_data_to_body(request: Request):
             web_search_filters=body.get("web_search_filters"),
             orchestrator_flag=body.get("orchestrator_flag"),
             chatbot=body.get("chatbot", False),
-            override_fields=body
+            override_fields=body,
+            environment=body.get("environment")
         )
 
         # Check if getConfiguration returned an error response

--- a/src/services/cache_utils.py
+++ b/src/services/cache_utils.py
@@ -11,7 +11,7 @@ from .cache_service import (
 )
 
 
-def extract_cache_tags(bridge_response: dict) -> list[str]:
+def extract_cache_tags(bridge_response: dict, environment: str | None = None) -> list[str]:
     """Return deduped reverse-index tag strings for a cached bridge response."""
     bridge = (bridge_response or {}).get("bridges") or {}
     if not isinstance(bridge, dict):
@@ -26,10 +26,15 @@ def extract_cache_tags(bridge_response: dict) -> list[str]:
         if s:
             tags.add(f"{prefix}{s}")
 
-    _add(tag_keys["agent"], bridge.get("parent_id"))
-
-    blob_id = bridge.get("_id")
     parent_id = bridge.get("parent_id")
+    blob_id = bridge.get("_id")
+    agent_id = parent_id or blob_id
+
+    _add(tag_keys["agent"], agent_id)
+
+    if environment and agent_id:
+        _add(tag_keys["agent"], f"{agent_id}_env_{environment}")
+
     if blob_id and parent_id and str(blob_id) != str(parent_id):
         _add(tag_keys["version"], blob_id)
 

--- a/src/services/utils/getConfiguration.py
+++ b/src/services/utils/getConfiguration.py
@@ -61,7 +61,8 @@ async def _prepare_configuration_response(
     web_search_filters=None,
     orchestrator_flag=None,
     chatbot=False,
-    override_fields={}
+    override_fields={},
+    environment=None
 ):
     """Internal helper to build configuration response for a single bridge."""
 
@@ -70,9 +71,14 @@ async def _prepare_configuration_response(
     built_in_tools = built_in_tools or []
     web_search_filters = web_search_filters or {}
 
-    # Fetch bridge data
-    agent_data, resolved_bridge_id = await get_bridge_data(bridge_id, org_id, version_id)
+    # Fetch bridge data (environment resolution happens inside the DB pipeline)
+    agent_data, resolved_bridge_id = await get_bridge_data(bridge_id, org_id, version_id, environment)
     bridges = agent_data.get("bridges", {})
+
+    # If environment resolved a version via pipeline, update version_id
+    if not version_id and environment and bridges.get("parent_id"):
+        version_id = bridges.get("_id")
+
     chatbot = bridges.get("bridgeType") == "chatbot"
 
     # Validate bridge existence and status before any limit checks
@@ -285,7 +291,7 @@ async def _prepare_configuration_response(
     return None, base_config, agent_data, resolved_bridge_id
 
 
-async def _collect_connected_agent_configs(agent_data, org_id, visited):
+async def _collect_connected_agent_configs(agent_data, org_id, visited, environment=None):
     """Recursively collect configurations for connected agents."""
 
     if not agent_data:
@@ -309,7 +315,7 @@ async def _collect_connected_agent_configs(agent_data, org_id, visited):
     aggregated_configs = {}
     if pending:
         async def _fetch_agent(bridge_id_value, merged_info):
-            version_id_value = merged_info.get("version_id")
+            env_val = merged_info.get("environment") or environment
             configuration_override = (
                 merged_info.get("configuration") if isinstance(merged_info.get("configuration"), dict) else None
             )
@@ -339,11 +345,12 @@ async def _collect_connected_agent_configs(agent_data, org_id, visited):
                     variables_override,
                     org_id,
                     variables_path_override,
-                    version_id_value,
+                    None,
                     extra_tools_override,
                     built_in_tools_override,
                     guardrails_override,
                     web_search_filters_override,
+                    environment=env_val,
                 )
             except Exception as exc:
                 logger.error(f"Error fetching configuration for connected agent {bridge_id_value}: {exc}")
@@ -353,12 +360,12 @@ async def _collect_connected_agent_configs(agent_data, org_id, visited):
                 logger.error(f"Skipping connected agent {bridge_id_value} due to error response: {error}")
                 return bridge_id_value, None, None, None
 
-            return bridge_id_value, child_config, child_agent_data, resolved_child_id
+            return bridge_id_value, child_config, child_agent_data, resolved_child_id, env_val
 
         # Fetch all sibling agents concurrently
         results = await asyncio.gather(*[_fetch_agent(bid, info) for bid, info in pending])
 
-        for bridge_id_value, child_config, child_agent_data, resolved_child_id in results:
+        for bridge_id_value, child_config, child_agent_data, resolved_child_id, resolved_env in results:
             if child_config is None:
                 continue
 
@@ -371,7 +378,7 @@ async def _collect_connected_agent_configs(agent_data, org_id, visited):
 
             aggregated_configs[key] = child_config
 
-            nested = await _collect_connected_agent_configs(child_agent_data, org_id, visited)
+            nested = await _collect_connected_agent_configs(child_agent_data, org_id, visited, environment=resolved_env)
             aggregated_configs.update(nested)
 
     reviewer_bridge_id_raw = bridge_payload.get("settings", {}).get("reviewer_agent")
@@ -382,6 +389,7 @@ async def _collect_connected_agent_configs(agent_data, org_id, visited):
                 None, None, reviewer_bridge_id, None,
                 None, None, org_id, None, None,
                 None, None, None, None,
+                environment=environment,
             )
         except Exception as exc:
             logger.error(f"Error fetching configuration for reviewer agent {reviewer_bridge_id}: {exc}")
@@ -396,7 +404,7 @@ async def _collect_connected_agent_configs(agent_data, org_id, visited):
                 visited.add(reviewer_bridge_id)
                 aggregated_configs[reviewer_bridge_id] = reviewer_config
 
-                nested = await _collect_connected_agent_configs(reviewer_agent_data, org_id, visited)
+                nested = await _collect_connected_agent_configs(reviewer_agent_data, org_id, visited, environment=environment)
                 aggregated_configs.update(nested)
 
     return aggregated_configs
@@ -418,7 +426,8 @@ async def getConfiguration(
     web_search_filters=None,
     orchestrator_flag=None,
     chatbot=False,
-    override_fields={}
+    override_fields={},
+    environment=None
 ):
     """
     Get configuration for a bridge with all necessary tools and settings.
@@ -440,7 +449,8 @@ async def getConfiguration(
         web_search_filters,
         orchestrator_flag,
         chatbot,
-        override_fields
+        override_fields,
+        environment
     )
 
     if error:
@@ -456,7 +466,7 @@ async def getConfiguration(
         if identifier:
             visited.add(identifier)
 
-    connected_configs = await _collect_connected_agent_configs(agent_data, org_id, visited)
+    connected_configs = await _collect_connected_agent_configs(agent_data, org_id, visited, environment=environment)
 
     bridge_configurations = {}
     if config_key:

--- a/src/services/utils/getConfiguration_utils.py
+++ b/src/services/utils/getConfiguration_utils.py
@@ -27,10 +27,10 @@ async def validate_bridge(agent_data):
     return None
 
 
-async def get_bridge_data(bridge_id, org_id, version_id):
+async def get_bridge_data(bridge_id, org_id, version_id, environment=None):
     """Fetch bridge data from database"""
     agent_data = await ConfigurationService.get_bridges_with_tools_and_apikeys(
-        bridge_id=bridge_id, org_id=org_id, version_id=version_id
+        bridge_id=bridge_id, org_id=org_id, version_id=version_id, environment=environment
     )
 
     bridge_id = bridge_id or agent_data.get("bridges", {}).get("parent_id")
@@ -363,16 +363,16 @@ def add_connected_agents(bridges, tools, tool_id_and_name_mapping, orchestrator_
 
     for _, bridge_info in connected_agents.items():
         bridge_id_value = bridge_info.get("bridge_id", "")
-        version_id_value = bridge_info.get("version_id", "")
-        # If version_id is present, use connected_agents data, otherwise use connected_agent_details
-        if version_id_value:
-            # Use data from connected_agents when version_id is present
+        environment_value = bridge_info.get("environment", "")
+        # If environment is present, use connected_agents data, otherwise use connected_agent_details
+        if environment_value:
+            # Use data from connected_agents when environment is present
             description = bridge_info.get("description", "")
             variables = bridge_info.get("variables", {})
             fields = variables.get("fields", {})
             required = variables.get("required", [])
         else:
-            # Use data from connected_agent_details when version_id is not present
+            # Use data from connected_agent_details when environment is not present
             agent_details = connected_agent_details.get(bridge_id_value)
             if agent_details and agent_details is not None:
                 description = agent_details.get("description", bridge_info.get("description", ""))
@@ -429,5 +429,4 @@ def add_connected_agents(bridges, tools, tool_id_and_name_mapping, orchestrator_
             "type": "AGENT",
             "bridge_id": bridge_id_value,
             "requires_thread_id": bridge_info.get("thread_id", False),
-            "version_id": version_id_value,
         }


### PR DESCRIPTION
- Added environment parameter to get_bridges_with_tools_and_apikeys and related functions to support environment-based version resolution
- Implemented MongoDB aggregation pipeline stages to resolve version_id from settings.environment_config when environment is provided without explicit version_id
- Updated cache key generation to include environment suffix when using environment resolution
- Modified parent bridge lookup logic