### PR TITLE
fix upstream connect error or disconnect/reset before headers. reset …

### DIFF
--- a/src/services/utils/apiservice.py
+++ b/src/services/utils/apiservice.py
@@ -9,8 +9,9 @@ import certifi
 
 async def fetch(url, method="GET", headers=None, params=None, json_body=None, image=None):
     ssl_context = ssl.create_default_context(cafile=certifi.where())
+    timeout = aiohttp.ClientTimeout(total=600, connect=15)
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(timeout=timeout) as session:
         body = None if method.upper() == "GET" else json_body
         async with session.request(
             method=method, url=url, headers=headers, params=params, json=body, ssl=ssl_context
@@ -34,7 +35,8 @@ async def fetch_stream(url, method="POST", headers=None, json_body=None):
     # 10 MiB buffer — large enough for SSE lines that embed base64 payloads
     # (e.g. OpenAI ``response.image_generation_call.partial_image``), which
     # exceed aiohttp's default ~128 KB per-line limit.
-    async with aiohttp.ClientSession(read_bufsize=64 * 1024 * 1024) as session:
+    timeout = aiohttp.ClientTimeout(total=900, connect=15, sock_read=120)
+    async with aiohttp.ClientSession(read_bufsize=64 * 1024 * 1024, timeout=timeout) as session:
         async with session.request(
             method=method, url=url, headers=headers, json=json_body, ssl=ssl_context
         ) as response:


### PR DESCRIPTION
…reason: connection timeout now support  600s for non-streaming and ≥ 900s for streaming