### PR TITLE
Add per-service timeouts with custom timeout error handling

### DIFF
--- a/src/db_services/ConfigurationServices.py
+++ b/src/db_services/ConfigurationServices.py
@@ -10,6 +10,7 @@ from src.configs.model_configuration import model_config_document
 
 from ..services.cache_service import delete_in_cache, find_in_cache, store_in_cache
 from ..services.cache_utils import extract_cache_tags, store_in_cache_with_tags
+from ..services.utils.time import with_timeout
 
 configurationModel = db["configurations"]
 apiCallModel = db["apicalls"]
@@ -80,7 +81,7 @@ async def get_bridges_with_redis(bridge_id=None, org_id=None, version_id=None):
             },
         ]
 
-        result = await model.aggregate(pipeline).to_list(length=None)
+        result = await with_timeout(model.aggregate(pipeline).to_list(length=None))
         bridges = result[0] if result else {}
         await store_in_cache(cache_key, result)
         return {
@@ -97,7 +98,7 @@ async def get_bridges_without_tools(bridge_id=None, org_id=None, version_id=None
     try:
         model = version_model if version_id else configurationModel
         id_to_use = ObjectId(version_id) if version_id else ObjectId(bridge_id)
-        bridge_data = await model.find_one({"_id": ObjectId(id_to_use)})
+        bridge_data = await with_timeout(model.find_one({"_id": ObjectId(id_to_use)}))
 
         if not bridge_data:
             raise errors.InvalidId("No matching bridge found")
@@ -652,7 +653,7 @@ async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None,
         ]
 
         # Execute the main aggregation pipeline
-        result = await model.aggregate(pipeline).to_list(length=None)
+        result = await with_timeout(model.aggregate(pipeline).to_list(length=None))
 
         if not result:
             return {"success": False, "error": "No matching records found"}
@@ -962,7 +963,7 @@ async def get_bridges_with_tools_and_apikeys(bridge_id, org_id, version_id=None,
             ]
 
             # Execute folder pipeline on folders collection
-            folder_result = await foldersModel.aggregate(folder_pipeline).to_list(length=None)
+            folder_result = await with_timeout(foldersModel.aggregate(folder_pipeline).to_list(length=None))
 
             # Append folder_apikeys to bridge_data if found
             if folder_result and folder_result[0].get("folder_apikeys"):
@@ -1108,7 +1109,7 @@ async def get_template_by_id(template_id):
             template_content = json.loads(template_content)
             return template_content
 
-        template_content = await templateModel.find_one({"_id": ObjectId(template_id)})
+        template_content = await with_timeout(templateModel.find_one({"_id": ObjectId(template_id)}))
         await store_in_cache(cache_key, template_content)
         return template_content
     except Exception as error:
@@ -1118,14 +1119,14 @@ async def get_template_by_id(template_id):
 
 async def get_bridge_by_slugname(org_id, slug_name):
     try:
-        bridge = await configurationModel.find_one({"slugName": slug_name, "org_id": org_id})
+        bridge = await with_timeout(configurationModel.find_one({"slugName": slug_name, "org_id": org_id}))
 
         if not bridge:
             raise BadRequestException("Bridge not found")
 
         if "responseRef" in bridge:
             response_ref_id = bridge["responseRef"]
-            response_ref = await configurationModel.find_one({"_id": response_ref_id})
+            response_ref = await with_timeout(configurationModel.find_one({"_id": response_ref_id}))
             bridge["responseRef"] = response_ref
 
         return bridge
@@ -1141,9 +1142,9 @@ async def update_bridge(bridge_id=None, update_fields=None, version_id=None, org
     id_to_use = ObjectId(version_id) if version_id else ObjectId(bridge_id)
     cache_key = f"{org_id}_{'version' if version_id else 'bridge'}_{version_id if version_id else bridge_id}"
 
-    updated_bridge = await model.find_one_and_update(
+    updated_bridge = await with_timeout(model.find_one_and_update(
         {"_id": ObjectId(id_to_use)}, {"$set": update_fields}, return_document=True, upsert=True
-    )
+    ))
 
     if not updated_bridge:
         raise BadRequestException("Bridge not found or no records updated")
@@ -1159,7 +1160,7 @@ async def update_bridge(bridge_id=None, update_fields=None, version_id=None, org
 
 
 async def get_agents_data(slug_name, user_email, org_id):
-    bridges = await configurationModel.find_one(
+    bridges = await with_timeout(configurationModel.find_one(
         {
             "$or": [
                 {"$and": [{"settings.publicAgentConfig.availability": "public"}, {"slugName": slug_name}, {"org_id": org_id}]},
@@ -1173,7 +1174,7 @@ async def get_agents_data(slug_name, user_email, org_id):
                 },
             ]
         }
-    )
+    ))
     return bridges
 
 
@@ -1194,7 +1195,7 @@ async def get_prompt_wrapper_by_id(wrapper_id: str, org_id: str | None = None):
         query["org_id"] = org_id
 
     try:
-        wrapper = await prompt_wrappersModel.find_one(query)
+        wrapper = await with_timeout(prompt_wrappersModel.find_one(query))
         if not wrapper:
             return None
         wrapper["_id"] = str(wrapper["_id"])

--- a/src/db_services/api_key_status_service.py
+++ b/src/db_services/api_key_status_service.py
@@ -1,6 +1,7 @@
 from bson import ObjectId
 from globals import logger
 from models.mongo_connection import db
+from src.services.utils.time import with_timeout
 
 apikeyCredentialsModel = db["apikeycredentials"]
 
@@ -9,10 +10,10 @@ async def update_apikey_status(apikey_id: str, status: str) -> bool:
         return False
 
     try:
-        result = await apikeyCredentialsModel.update_one(
+        result = await with_timeout(apikeyCredentialsModel.update_one(
             {"_id": ObjectId(apikey_id)},
             {"$set": {"status": status}}
-        )
+        ))
         if not result.modified_count:
             logger.warning(f"No apikey credential updated for id={apikey_id}")
             return False

--- a/src/db_services/testcase_services.py
+++ b/src/db_services/testcase_services.py
@@ -5,17 +5,18 @@ from fastapi import HTTPException
 
 from globals import logger
 from models.mongo_connection import db
+from src.services.utils.time import with_timeout
 
 configurationModel = db["configurations"]
 testcases_model = db["testcases"]
 
 
 async def get_testcases(bridge_id):
-    return await testcases_model.find({"bridge_id": bridge_id}).to_list(length=None)
+    return await with_timeout(testcases_model.find({"bridge_id": bridge_id}).to_list(length=None))
 
 
 async def create_testcase(testcase_data):
-    result = await testcases_model.insert_one(testcase_data)
+    result = await with_timeout(testcases_model.insert_one(testcase_data))
     return result
 
 
@@ -23,7 +24,7 @@ async def delete_testcase_by_id(testcase_id):
     """Delete a testcase by _id"""
     try:
         object_id = ObjectId(testcase_id)
-        result = await testcases_model.delete_one({"_id": object_id})
+        result = await with_timeout(testcases_model.delete_one({"_id": object_id}))
         return result
     except Exception as e:
         logger.error(f"Error deleting testcase: {str(e)}")
@@ -32,14 +33,14 @@ async def delete_testcase_by_id(testcase_id):
 
 async def get_all_testcases_by_bridge_id(bridge_id):
     """Get all testcases for a specific bridge_id"""
-    return await testcases_model.find({"bridge_id": bridge_id}).to_list(length=None)
+    return await with_timeout(testcases_model.find({"bridge_id": bridge_id}).to_list(length=None))
 
 
 async def get_testcase_by_id(testcase_id):
     """Get a testcase by _id"""
     try:
         object_id = ObjectId(testcase_id)
-        return await testcases_model.find_one({"_id": object_id})
+        return await with_timeout(testcases_model.find_one({"_id": object_id}))
     except Exception as e:
         logger.error(f"Error fetching testcase: {str(e)}")
         raise e
@@ -50,7 +51,7 @@ async def update_testcase_by_id(testcase_id, update_data):
     try:
         object_id = ObjectId(testcase_id)
         update_data["updated_at"] = datetime.datetime.utcnow()
-        result = await testcases_model.update_one({"_id": object_id}, {"$set": update_data})
+        result = await with_timeout(testcases_model.update_one({"_id": object_id}, {"$set": update_data}))
         return result
     except Exception as e:
         logger.error(f"Error updating testcase: {str(e)}")
@@ -72,10 +73,10 @@ async def update_testcase_last_executed(testcase_ids):
         if not object_ids:
             return None
         now = datetime.datetime.utcnow()
-        result = await testcases_model.update_many(
+        result = await with_timeout(testcases_model.update_many(
             {"_id": {"$in": object_ids}},
             {"$set": {"execution.lastExecutedAt": now, "updatedAt": now}},
-        )
+        ))
         return result
     except Exception as e:
         logger.error(f"Error updating testcase lastExecutedAt: {str(e)}")

--- a/src/db_services/webhook_alert_Dbservice.py
+++ b/src/db_services/webhook_alert_Dbservice.py
@@ -1,12 +1,13 @@
 from globals import logger
 from models.mongo_connection import db
+from src.services.utils.time import with_timeout
 
 alertModel = db["alerts"]
 
 
 async def get_webhook_data(org_id):
     try:
-        webhook_data = await alertModel.find({"org_id": org_id}).to_list(length=None)
+        webhook_data = await with_timeout(alertModel.find({"org_id": org_id}).to_list(length=None))
         return {"webhook_data": webhook_data or []}
     except Exception as error:
         logger.error(f"Error in get_webhook_data: %s, {str(error)}")

--- a/src/handler/executionHandler.py
+++ b/src/handler/executionHandler.py
@@ -5,9 +5,24 @@ import traceback
 from functools import wraps
 
 from fastapi.responses import JSONResponse
+from openai import APITimeoutError
+from pymongo.errors import ExecutionTimeout, NetworkTimeout, ServerSelectionTimeoutError
+from redis.exceptions import TimeoutError as RedisTimeoutError
 
+from globals import logger
 from src.configs.constant import alert_types
 from src.send_alert import send_alert
+from src.services.utils.time import TIMEOUT_ERROR_MESSAGE
+
+_TIMEOUT_EXC = (
+    ServerSelectionTimeoutError,
+    NetworkTimeout,
+    ExecutionTimeout,
+    RedisTimeoutError,
+    APITimeoutError,
+    asyncio.TimeoutError,
+    TimeoutError,
+)
 
 
 def handle_exceptions(func):
@@ -34,23 +49,27 @@ def handle_exceptions(func):
                     "location_string": f"{last_frame.filename.split('/')[-1]}:{last_frame.lineno}"
                 }
 
-            if isinstance(exc, ValueError):
-                error_details = exc.args[0] if exc.args else str(exc)
+            if isinstance(exc, _TIMEOUT_EXC):
+                logger.error(f"[TIMEOUT] {type(exc).__name__}: {exc}")
+                error_json = {"error": TIMEOUT_ERROR_MESSAGE}
             else:
-                error_details = str(exc)
+                if isinstance(exc, ValueError):
+                    error_details = exc.args[0] if exc.args else str(exc)
+                else:
+                    error_details = str(exc)
 
-            if isinstance(error_details, ValueError):
-                error_details = error_details.args[0] if error_details.args else str(error_details)
+                if isinstance(error_details, ValueError):
+                    error_details = error_details.args[0] if error_details.args else str(error_details)
 
-            if isinstance(error_details, dict):
-                error_json = error_details
-            elif isinstance(error_details, str):
-                try:
-                    error_json = json.loads(error_details)
-                except json.JSONDecodeError:
-                    error_json = {"error_message": error_details}
-            else:
-                error_json = {"error_message": str(error_details)}               
+                if isinstance(error_details, dict):
+                    error_json = error_details
+                elif isinstance(error_details, str):
+                    try:
+                        error_json = json.loads(error_details)
+                    except json.JSONDecodeError:
+                        error_json = {"error_message": error_details}
+                else:
+                    error_json = {"error_message": str(error_details)}
             body = request_body.get("body", {})
             bridge_id = path_params.get("bridge_id") or body.get("bridge_id")
             org_id = state.get("profile", {}).get("org", {}).get("id")

--- a/src/services/cache_service.py
+++ b/src/services/cache_service.py
@@ -5,9 +5,14 @@ from redis.asyncio import Redis
 
 from config import Config
 from globals import logger
+from src.services.utils.time import SERVICE_TIMEOUTS
 
 # Initialize the Redis client
-client = Redis.from_url(Config.REDIS_URI)  # Adjust these parameters as needed
+client = Redis.from_url(
+    Config.REDIS_URI,
+    socket_timeout=SERVICE_TIMEOUTS["redis"],  # 10s read/write
+    socket_connect_timeout=SERVICE_TIMEOUTS["redis"],  # 10s connect
+)
 
 REDIS_PREFIX = f"AIMIDDLEWARE_{Config.ENVIRONMENT}_"
 DEFAULT_REDIS_TTL = 172800  # 2 days

--- a/src/services/commonServices/baseService/utils.py
+++ b/src/services/commonServices/baseService/utils.py
@@ -18,6 +18,7 @@ from src.services.cache_service import REDIS_PREFIX, client, find_in_cache, incr
 from src.services.mcp_gateway.client import call_mcp_tool
 from src.services.utils.ai_call_util import call_gtwy_agent
 from src.services.utils.apiservice import fetch
+from src.services.utils.time import SERVICE_TIMEOUTS
 from src.services.utils.built_in_tools.firecrawl import call_firecrawl_scrape
 
 
@@ -172,8 +173,9 @@ async def axios_work(data, function_payload):
             data,
             function_payload.get("query_params", []),
         )
-        response, rs_headers = await fetch(
-            resolved_url, method, function_payload.get("headers", {}), query_params, body
+        response, rs_headers = await asyncio.wait_for(
+            fetch(resolved_url, method, function_payload.get("headers", {}), query_params, body),
+            timeout=SERVICE_TIMEOUTS["pre_function"],
         )  # required is not send then it will still hit the curl
         return {
             "response": response,

--- a/src/services/commonServices/response_caching_utils.py
+++ b/src/services/commonServices/response_caching_utils.py
@@ -2,6 +2,7 @@ from config import Config
 from globals import logger
 from models.mongo_connection import db
 from src.services.utils.apiservice import fetch
+from src.services.utils.time import with_timeout
 
 HIPPOCAMPUS_SEARCH_URL = "http://hippocampus.gtwy.ai/search"
 agent_memory_collection = db["agent_memories"]
@@ -63,7 +64,7 @@ async def get_response_using_resourceid(resource_id: str) -> dict:
         logger.info("Mongo cache lookup skipped: empty resource_id")
         return {"found": False, "answer": None}
 
-    memory = await agent_memory_collection.find_one({"resource_id": resource_id})
+    memory = await with_timeout(agent_memory_collection.find_one({"resource_id": resource_id}))
     if not memory:
         logger.info(f"Mongo cache miss for resource_id={resource_id}")
         return {"found": False, "answer": None}

--- a/src/services/prebuilt_prompt_service.py
+++ b/src/services/prebuilt_prompt_service.py
@@ -1,6 +1,7 @@
 from fastapi import HTTPException
 
 from models.mongo_connection import db
+from src.services.utils.time import with_timeout
 
 prebuilt_db = db["preBuiltPrompts"]
 
@@ -20,7 +21,7 @@ async def get_specific_prebuilt_prompt_service(org_id: str, prompt_key: str):
         # Query specific prebuilt prompt for the organization
         query = {"org_id": org_id}
         projection = {"_id": 0, f"prebuilt_prompts.{prompt_key}": 1}
-        document = await prebuilt_db.find_one(query, projection)
+        document = await with_timeout(prebuilt_db.find_one(query, projection))
 
         if document and document.get("prebuilt_prompts") and document["prebuilt_prompts"].get(prompt_key):
             return {prompt_key: document["prebuilt_prompts"][prompt_key]}
@@ -36,7 +37,8 @@ async def get_multiple_prebuilt_prompts_without_org_service(prompt_keys: list[st
         query = {"$or": [{key: {"$exists": True}} for key in prompt_keys]}
         projection = {"_id": 0, **{key: 1 for key in prompt_keys}}
         result = {}
-        async for document in prebuilt_db.find(query, projection).sort("_id", -1):
+        documents = await with_timeout(prebuilt_db.find(query, projection).sort("_id", -1).to_list(length=None))
+        for document in documents:
             for key in prompt_keys:
                 if key not in result and document.get(key):
                     result[key] = document[key]
@@ -55,7 +57,7 @@ async def get_specific_prebuilt_prompt_without_org_service(prompt_key: str):
             ]
         }
         projection = {"_id": 0, prompt_key: 1}
-        document = await prebuilt_db.find_one(query, projection, sort=[("_id", -1)])
+        document = await with_timeout(prebuilt_db.find_one(query, projection, sort=[("_id", -1)]))
 
         if document and document.get(prompt_key):
             return {prompt_key: document[prompt_key]}

--- a/src/services/testcase_service.py
+++ b/src/services/testcase_service.py
@@ -22,6 +22,7 @@ from models.mongo_connection import db
 from src.services.commonServices.baseService.utils import send_message
 from src.services.commonServices.common import chat
 from src.services.utils.getConfiguration import getConfiguration
+from src.services.utils.time import with_timeout
 
 logger = logging.getLogger(__name__)
 
@@ -191,7 +192,7 @@ async def fetch_testcases_from_request(
             object_ids = [ObjectId(tid) for tid in testcase_ids]
         except Exception as e:
             raise TestcaseValidationError(f"Invalid testcase id in testcase_ids: {str(e)}")
-        testcases = await testcases_collection.find({"_id": {"$in": object_ids}}).to_list(length=None)
+        testcases = await with_timeout(testcases_collection.find({"_id": {"$in": object_ids}}).to_list(length=None))
         if not testcases:
             raise TestcaseNotFoundError("No testcases found for the given testcase_ids")
         # Preserve the order in which ids were supplied.
@@ -200,13 +201,13 @@ async def fetch_testcases_from_request(
         return testcases
 
     if testcase_id:
-        testcase = await testcases_collection.find_one({"_id": ObjectId(testcase_id)})
+        testcase = await with_timeout(testcases_collection.find_one({"_id": ObjectId(testcase_id)}))
         if not testcase:
             raise TestcaseNotFoundError("No testcase found for the given testcase_id")
         return [testcase]
 
     # No testcase_id(s) -> fetch all testcases for bridge_id
-    testcases = await testcases_collection.find({"bridge_id": bridge_id}).to_list(length=None)
+    testcases = await with_timeout(testcases_collection.find({"bridge_id": bridge_id}).to_list(length=None))
     if not testcases:
         raise TestcaseNotFoundError("No testcases found for the given bridge_id")
     return testcases

--- a/src/services/utils/load_model_configs.py
+++ b/src/services/utils/load_model_configs.py
@@ -1,5 +1,6 @@
 from globals import logger
 from models.mongo_connection import db
+from src.services.utils.time import with_timeout
 
 modelConfigModel = db["modelconfigurations"]
 
@@ -7,7 +8,7 @@ modelConfigModel = db["modelconfigurations"]
 async def get_model_configurations():
     try:
         # Remove the projection to allow _id to be included in the results
-        configurations = await modelConfigModel.find({"status": 1}, {"_id": 0}).to_list(length=None)
+        configurations = await with_timeout(modelConfigModel.find({"status": 1}, {"_id": 0}).to_list(length=None))
         config_dict = {}
         for conf in configurations:
             conf_dict = dict(conf)

--- a/src/services/utils/load_service_configs.py
+++ b/src/services/utils/load_service_configs.py
@@ -1,5 +1,6 @@
 from globals import logger
 from models.mongo_connection import db
+from src.services.utils.time import with_timeout
 
 serviceConfigModel = db["services"]
 
@@ -11,7 +12,7 @@ async def get_service_configs():
     callers can fall back to the hardcoded defaults in service_registry.py.
     """
     try:
-        services = await serviceConfigModel.find({"status": 1}, {"_id": 0}).to_list(length=None)
+        services = await with_timeout(serviceConfigModel.find({"status": 1}, {"_id": 0}).to_list(length=None))
         config_dict = {}
         for svc in services:
             svc_dict = dict(svc)

--- a/src/services/utils/time.py
+++ b/src/services/utils/time.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 
 
@@ -25,3 +26,38 @@ class Timer:
 
 
 timer_obj = Timer()
+
+
+# Thresholds in seconds for slow-call warnings
+SLOW_CALL_THRESHOLDS = {
+    "redis": 0.1,       # 100ms
+    "mongo": 0.5,        # 500ms
+    "pre_function": 5.0,  # 5s
+    "openai_batch": 10.0, # 10s
+    "batch_retrieve": 3.0, # 3s
+}
+
+
+def log_slow_call(label: str, elapsed: float, threshold: float) -> None:
+    """Prints a warning only when elapsed exceeds threshold (seconds)."""
+    if elapsed > threshold:
+        print(f"[SLOW] {label} took {elapsed * 1000:.1f}ms (threshold {threshold * 1000:.0f}ms)")
+
+
+# Hard maximum execution time per service (seconds)
+SERVICE_TIMEOUTS = {
+    "mongo": 60,
+    "redis": 10,
+    "pre_function": 60,
+}
+
+TIMEOUT_ERROR_MESSAGE = "Due to a technical issue we couldn't fulfil your request, please try again."
+
+
+async def with_timeout(coro, service: str = "mongo"):
+    """Await `coro` with the per-service ceiling; raises asyncio.TimeoutError on breach."""
+    try:
+        return await asyncio.wait_for(coro, SERVICE_TIMEOUTS[service])
+    except asyncio.TimeoutError:
+        print(f"[TIMEOUT] {service} call exceeded {SERVICE_TIMEOUTS[service]}s")
+        raise


### PR DESCRIPTION
- Add SERVICE_TIMEOUTS config + with_timeout helper in time.py
- Wrap every MongoDB query with a 60s per-query timeout (asyncio.wait_for)
- Set Redis client socket timeouts (10s read/connect)
- Bound pre_function (sokt.io) calls at 30s; request continues on timeout
- Translate timeout exceptions to a friendly 400 centrally (executionHandler decorator + global FastAPI handler in index.py)