### PR TITLE
feat: add in-place update for testcase data

### DIFF
--- a/src/db_services/metrics_service.py
+++ b/src/db_services/metrics_service.py
@@ -525,5 +525,38 @@ async def publish_plan_history_update(
         logger.error(traceback.format_exc())
 
 
+async def publish_testcase_data_update(*, message_id, testcase_id, testcase_data):
+    """
+    Publish an update_history message that updates ONLY the testcase columns
+    (testcase_id, testcase_data) of an existing conversation_logs row, matched
+    by message_id.
+
+    Used when POST /api/v2/model/testcases is called with a message_id so the
+    testcase is re-scored in place against an already-logged message instead of
+    creating a new history row. The Node consumer whitelist-updates by
+    message_id alone (no org_id), so the org_id-is-None case is irrelevant here.
+    """
+    try:
+        from ..services.cache_service import make_json_serializable
+        from ..services.commonServices.queueService.queueLogService import sub_queue_obj
+
+        if not message_id:
+            logger.error("publish_testcase_data_update: missing message_id — cannot update history row")
+            return
+
+        update_data = {
+            "message_id": str(message_id),
+            "testcase_id": testcase_id,
+            "testcase_data": testcase_data,
+        }
+        message = make_json_serializable({"update_history": update_data})
+        await sub_queue_obj.publish_message(message)
+        logger.info(f"Published testcase_data update for message_id: {message_id}")
+
+    except Exception as error:
+        logger.error(f"Error publishing testcase_data update: {str(error)}")
+        logger.error(traceback.format_exc())
+
+
 # Exporting functions
-__all__ = ["find", "find_one", "find_one_pg", "create_batch_conversation_logs", "build_history_and_metrics_payload", "build_orchestrator_log_data", "publish_plan_history_update"]
+__all__ = ["find", "find_one", "find_one_pg", "create_batch_conversation_logs", "build_history_and_metrics_payload", "build_orchestrator_log_data", "publish_plan_history_update", "publish_testcase_data_update"]

--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -656,6 +656,21 @@ async def chat(request_body):
                     "is_overridden": parsed_data.get("testcase_data", {}).get("is_overridden", False),
                 }
 
+            # In-place update mode: when a message_id was supplied on the
+            # /testcases request, update only the testcase columns of that
+            # existing conversation_logs row instead of creating a new history
+            # row. Skip the normal save_history/metrics publish below.
+            update_message_id = parsed_data.get("testcase_data", {}).get("update_message_id")
+            if update_message_id:
+                from src.db_services.metrics_service import publish_testcase_data_update
+                hp = result.get("historyParams") or {}
+                await publish_testcase_data_update(
+                    message_id=update_message_id,
+                    testcase_id=hp.get("testcase_id"),
+                    testcase_data=hp.get("testcase_data"),
+                )
+                parsed_data["skip_history"] = True
+
             if parsed_data.get("body", {}).get("bridge_configurations", {}).get("playground_response_format"):
                 await sendResponse(
                     parsed_data["body"]["bridge_configurations"]["playground_response_format"],

--- a/src/services/testcase_service.py
+++ b/src/services/testcase_service.py
@@ -110,6 +110,17 @@ def validate_testcase_request_data(body: dict[str, Any]) -> dict[str, Any]:
             if not isinstance(m, dict) or not m.get("model") or not m.get("service"):
                 raise TestcaseValidationError("each entry in models must include 'model' and 'service'")
 
+    # In-place update mode: a message_id targets a single existing
+    # conversation_logs row, so it is only valid for a single result — one
+    # version, no model/service overrides, and (checked later, once resolved)
+    # exactly one testcase.
+    message_id = body.get("message_id")
+    if message_id and (len(version_ids) > 1 or models or model_override or service_override):
+        raise TestcaseValidationError(
+            "message_id is only supported for a single-result run: one version_id and no "
+            "model/service/models overrides."
+        )
+
     return {
         "bridge_id": bridge_id,
         "version_ids": version_ids,
@@ -122,6 +133,7 @@ def validate_testcase_request_data(body: dict[str, Any]) -> dict[str, Any]:
         "model_override": model_override,
         "service_override": service_override,
         "models": models or [],
+        "message_id": message_id,
     }
 
 
@@ -265,6 +277,8 @@ async def process_single_testcase(
     override_matching_type: str | None,
     rtlayer_cred: dict[str, Any] | None = None,
     version_id: str | None = None,
+    message_id: str | None = None,
+    org_id: str | None = None,
 ) -> dict[str, Any]:
     """
     Process a single testcase
@@ -312,6 +326,20 @@ async def process_single_testcase(
             },
             "state": {"version": 2, "timer": [time.time()]},
         }
+
+        # The testcase request is constructed without the request profile, so
+        # parse_request_body can't derive org_id from state.profile. Stamp it on
+        # the body directly so the persisted conversation_logs row carries the
+        # correct org_id (parse reads `body.get("org_id")` as the fallback).
+        if org_id:
+            testcase_request_data["body"]["org_id"] = org_id
+
+        # In-place update mode: when a message_id is supplied, target the
+        # existing conversation_logs row instead of creating a new one. The flag
+        # is read in common.chat()'s testcase-scoring block.
+        if message_id:
+            testcase_request_data["body"]["message_id"] = message_id
+            testcase_request_data["body"]["testcase_data"]["update_message_id"] = message_id
 
         # Call chat function
         result = await chat(testcase_request_data)
@@ -421,6 +449,8 @@ async def run_testcases_parallel(
     override_matching_type: str | None,
     rtlayer_cred: dict[str, Any] | None = None,
     version_id: str | None = None,
+    message_id: str | None = None,
+    org_id: str | None = None,
 ) -> list[dict[str, Any]]:
     """
     Run multiple testcases in parallel.
@@ -438,7 +468,7 @@ async def run_testcases_parallel(
     results = await asyncio.gather(
         *[
             process_single_testcase(
-                tc, copy.deepcopy(db_config), override_matching_type, rtlayer_cred, version_id
+                tc, copy.deepcopy(db_config), override_matching_type, rtlayer_cred, version_id, message_id, org_id
             )
             for tc in testcases
         ]
@@ -492,6 +522,11 @@ async def execute_testcases(
     )
 
     version_ids = request_data["version_ids"]
+    update_message_id = request_data.get("message_id")
+    if update_message_id and len(testcases) != 1:
+        raise TestcaseValidationError(
+            "message_id is only supported when exactly one testcase is run."
+        )
 
     await _publish_event(
         rtlayer_cred,
@@ -586,6 +621,8 @@ async def execute_testcases(
                 request_data["matching_type"],
                 rtlayer_cred=rtlayer_cred,
                 version_id=version_id,
+                message_id=update_message_id,
+                org_id=org_id,
             )
         tools_call_data = []
         if results and isinstance(results[0], dict):


### PR DESCRIPTION
- Introduced `publish_testcase_data_update` function to handle updates to existing conversation logs based on `message_id`.
- Updated `validate_testcase_request_data` to enforce single-result constraints when `message_id` is present.
- Modified `process_single_testcase` and `run_testcases_parallel` to support passing `message_id` and `org_id`.
- Enhanced `chat` function to skip normal history publishing when an update is triggered by `message_id`.