### PR TITLE
refactor: added gpt memory tool

### DIFF
--- a/src/configs/constant.py
+++ b/src/configs/constant.py
@@ -96,7 +96,10 @@ tag_keys = {
 
 limit_types = {"bridge": "bridge", "folder": "folder", "apikey": "apikey"}
 
-inbuild_tools = {"Gtwy_Web_Search": "Gtwy_Web_Search"}
+inbuild_tools = {
+    "Gtwy_Web_Search": "Gtwy_Web_Search",
+    "get_gpt_memory": "get_gpt_memory",
+}
 
 VALID_RESPONSE_TYPES = {"text", "json_object", "json_schema"}
 

--- a/src/db_services/conversationDbService.py
+++ b/src/db_services/conversationDbService.py
@@ -43,7 +43,7 @@ async def find_conversation_logs(org_id, thread_id, sub_thread_id, bridge_id):
                 )
             )
             .order_by(ConversationLog.created_at.desc())
-            .limit(3)
+            .limit(1)
             .all()
         )
         log_slow_call("PG query find_conversation_logs", _time.time() - _t, SLOW_CALL_THRESHOLDS["pg"])

--- a/src/services/commonServices/baseService/utils.py
+++ b/src/services/commonServices/baseService/utils.py
@@ -20,6 +20,7 @@ from src.services.utils.ai_call_util import call_gtwy_agent
 from src.services.utils.apiservice import fetch
 from src.services.utils.time import SERVICE_TIMEOUTS
 from src.services.utils.built_in_tools.firecrawl import call_firecrawl_scrape
+from src.services.utils.built_in_tools.gpt_memory import call_get_gpt_memory
 
 
 def clean_json(data):
@@ -462,6 +463,8 @@ async def process_data_and_run_tools(codes_mapping, self):
                     task = call_gtwy_agent(agent_args)
                 elif self.tool_id_and_name_mapping[name].get("type") == inbuild_tools["Gtwy_Web_Search"]:
                     task = call_firecrawl_scrape(tool_data.get("args"))
+                elif self.tool_id_and_name_mapping[name].get("type") == inbuild_tools["get_gpt_memory"]:
+                    task = call_get_gpt_memory(tool_data.get("args"), self.memory)
                 elif self.tool_id_and_name_mapping[name].get("type") == "MCP":
                     task = call_mcp_tool(tool_data.get("args"), self.tool_id_and_name_mapping[name])
                 else:

--- a/src/services/commonServices/common.py
+++ b/src/services/commonServices/common.py
@@ -16,6 +16,7 @@ from src.services.auto_router_service import apply_auto_model_selection
 from src.services.cache_service import find_in_cache, store_in_cache
 from src.services.todo.planner_service import prepare_planner_request
 from src.services.todo.todo_handler import handle_todo_mode
+from src.services.utils.gpt_memory_tool import attach_gpt_memory_tool
 from src.services.utils.common_utils import (
     add_default_template,
     add_files_to_parse_data,
@@ -278,7 +279,14 @@ async def chat(request_body):
 
 
         # Step 7: Prepare Prompt, Variables and Memory
+        # prepare_prompt loads GPT memory via get_gpt_memory (cache/plug) when enabled.
+        # attach_gpt_memory_tool then registers get_gpt_memory + prompt from live page keys
+        # (or adds nothing when there is no memory).
         memory, missing_vars = await prepare_prompt(parsed_data, thread_info, model_config, custom_config)
+        attach_gpt_memory_tool(parsed_data, memory)
+        # custom_config was built before memory tool registration — keep tools in sync
+        if parsed_data.get("configuration", {}).get("tools") is not None:
+            custom_config["tools"] = parsed_data["configuration"]["tools"]
 
         missing_vars = filter_missing_vars(missing_vars, parsed_data["variables_state"])
 

--- a/src/services/commonServices/createConversations.py
+++ b/src/services/commonServices/createConversations.py
@@ -1,4 +1,3 @@
-import json
 import mimetypes
 import traceback
 from urllib.parse import urlparse
@@ -6,12 +5,6 @@ from urllib.parse import urlparse
 from globals import logger
 
 from ..utils.apiservice import fetch_images_b64
-
-
-def _format_memory(memory):
-    if isinstance(memory, dict):
-        return json.dumps(memory, ensure_ascii=False)
-    return memory
 
 
 class ConversationService:
@@ -22,14 +15,9 @@ class ConversationService:
             # Track distinct PDF URLs across the entire conversation
             seen_pdf_urls = set()
 
-            if memory is not None:
-                threads.append(
-                    {
-                        "role": "user",
-                        "content": "provide the summary of the previous conversation stored in the memory?",
-                    }
-                )
-                threads.append({"role": "assistant", "content": f"Summary of previous conversations :  {_format_memory(memory)}"})
+            # GPT memory is no longer injected into history; it will be exposed via tool later.
+            # `memory` is kept in the signature for call-site compatibility.
+            _ = memory
             for message in conversation or []:
                 if message['role'] not in ["tools_call", "tool"]:
                     has_media = 'user_urls' in message and isinstance(message['user_urls'], list) and len(message['user_urls']) > 0
@@ -79,10 +67,8 @@ class ConversationService:
                 conversation = []
             threads = []
             # Track distinct PDF URLs across the entire conversation
-
-            if memory is not None:
-                threads.append({"role": "user", "content": [{"type": "text", "text": f"GPT-Memory Data:- {_format_memory(memory)}"}]})
-                threads.append({"role": "assistant", "content": [{"type": "text", "text": "memory updated."}]})
+            # GPT memory is no longer injected into history; kept for call-site compatibility.
+            _ = memory
 
             # Process image URLs if present
             image_urls = [url.get("url") for message in conversation for url in message.get("user_urls", [])]
@@ -147,9 +133,8 @@ class ConversationService:
         try:
             threads = []
 
-            # If memory is provided, add it as the first message
-            if memory is not None:
-                threads.append({"role": "user", "content": _format_memory(memory)})
+            # GPT memory is no longer injected into history; kept for call-site compatibility.
+            _ = memory
 
             # Loop through the conversation to build the message threads
             for message in conversation or []:
@@ -185,14 +170,8 @@ class ConversationService:
         """
         try:
             threads = []
-            if memory is not None:
-                threads.append(
-                    {
-                        "role": "user",
-                        "content": "provide the summary of the previous conversation stored in the memory?",
-                    }
-                )
-                threads.append({"role": "assistant", "content": f"Summary of previous conversations :  {_format_memory(memory)}"})
+            # GPT memory is no longer injected into history; kept for call-site compatibility.
+            _ = memory
             for message in conversation or []:
                 if message["role"] != "tools_call" and message["role"] != "tool":
                     content = [{"type": "text", "text": message["content"]}]
@@ -216,10 +195,9 @@ class ConversationService:
         from google.genai import types
         try:
             contents = []
-            if memory is not None:
-                contents.append(types.Content(role='user', parts=[types.Part(text='Please Provide the summary of the previous conversation stored in the memory.')]))
-                contents.append(types.Content(role='model', parts=[types.Part(text=f'Summary of previous conversations: {_format_memory(memory)}')]))
-            
+            # GPT memory is no longer injected into history; kept for call-site compatibility.
+            _ = memory
+
             for message in conversation or []:
                 role = message.get('role')
                 if role not in {'tools_calls', "tools"}:

--- a/src/services/commonServices/createConversations.py
+++ b/src/services/commonServices/createConversations.py
@@ -15,9 +15,6 @@ class ConversationService:
             # Track distinct PDF URLs across the entire conversation
             seen_pdf_urls = set()
 
-            # GPT memory is no longer injected into history; it will be exposed via tool later.
-            # `memory` is kept in the signature for call-site compatibility.
-            _ = memory
             for message in conversation or []:
                 if message['role'] not in ["tools_call", "tool"]:
                     has_media = 'user_urls' in message and isinstance(message['user_urls'], list) and len(message['user_urls']) > 0
@@ -67,8 +64,6 @@ class ConversationService:
                 conversation = []
             threads = []
             # Track distinct PDF URLs across the entire conversation
-            # GPT memory is no longer injected into history; kept for call-site compatibility.
-            _ = memory
 
             # Process image URLs if present
             image_urls = [url.get("url") for message in conversation for url in message.get("user_urls", [])]
@@ -133,9 +128,6 @@ class ConversationService:
         try:
             threads = []
 
-            # GPT memory is no longer injected into history; kept for call-site compatibility.
-            _ = memory
-
             # Loop through the conversation to build the message threads
             for message in conversation or []:
                 if message["role"] not in ["tools_call", "tool"]:  # Skip tool-related roles
@@ -170,8 +162,6 @@ class ConversationService:
         """
         try:
             threads = []
-            # GPT memory is no longer injected into history; kept for call-site compatibility.
-            _ = memory
             for message in conversation or []:
                 if message["role"] != "tools_call" and message["role"] != "tool":
                     content = [{"type": "text", "text": message["content"]}]
@@ -195,8 +185,6 @@ class ConversationService:
         from google.genai import types
         try:
             contents = []
-            # GPT memory is no longer injected into history; kept for call-site compatibility.
-            _ = memory
 
             for message in conversation or []:
                 role = message.get('role')

--- a/src/services/utils/built_in_tools/gpt_memory.py
+++ b/src/services/utils/built_in_tools/gpt_memory.py
@@ -1,0 +1,57 @@
+"""Built-in get_gpt_memory tool — local executor (same pattern as firecrawl)."""
+
+from __future__ import annotations
+
+import json
+
+from src.services.utils.gpt_memory import get_memory_page_keys, get_memory_pages
+
+
+async def call_get_gpt_memory(args, memory):
+    """
+    Execute get_gpt_memory from LLM tool-call args.
+
+    Args:
+      keys: list[str] — page keys to return
+      all: bool — if true, return every page (keys ignored)
+
+    Returns the standard tool result shape used by baseService.
+    """
+    args = args if isinstance(args, dict) else {}
+    include_all = bool(args.get("all"))
+    keys = args.get("keys")
+    if keys is not None and not isinstance(keys, list):
+        keys = [keys]
+
+    available = get_memory_page_keys(memory)
+    if not available:
+        return {
+            "response": {"error": "No GPT memory available for this thread.", "available_keys": []},
+            "metadata": {"type": "function"},
+            "status": 0,
+        }
+
+    if not include_all and not keys:
+        return {
+            "response": {
+                "error": "Provide keys or set all=true.",
+                "available_keys": available,
+            },
+            "metadata": {"type": "function"},
+            "status": 0,
+        }
+
+    pages = get_memory_pages(memory, keys=keys, include_all=include_all)
+    try:
+        json.dumps(pages)
+    except (TypeError, ValueError):
+        pages = json.loads(json.dumps(pages, default=str))
+
+    return {
+        "response": {
+            "pages": pages,
+            "available_keys": available,
+        },
+        "metadata": {"type": "function"},
+        "status": 1,
+    }

--- a/src/services/utils/common_utils.py
+++ b/src/services/utils/common_utils.py
@@ -656,6 +656,31 @@ async def handle_post_tool(parsed_data, result):
         if isinstance(result, dict) and result.get("response", {}).get("data") is not None:
             result["response"]["data"]["content"] = post_tool_response.get("response")
 
+
+def take_last_conversation_turn(messages):
+    """
+    Keep only the last conversation turn for the LLM.
+
+    A turn starts at the last message with role "user" and includes everything
+    after it (optional tools_call, assistant, etc.).
+    """
+    if not messages:
+        return []
+    if not isinstance(messages, list):
+        return messages
+
+    last_user_idx = None
+    for i in range(len(messages) - 1, -1, -1):
+        if isinstance(messages[i], dict) and messages[i].get("role") == "user":
+            last_user_idx = i
+            break
+
+    if last_user_idx is None:
+        return messages[-1:] if messages else []
+
+    return messages[last_user_idx:]
+
+
 async def manage_threads(parsed_data):
     thread_id = parsed_data["thread_id"]
     sub_thread_id = parsed_data["sub_thread_id"]
@@ -677,15 +702,18 @@ async def manage_threads(parsed_data):
         cached_conversations = await find_in_cache(redis_key)
 
         if cached_conversations:
-            # Use cached conversations from Redis
-            parsed_data["configuration"]["conversation"] = json.loads(cached_conversations)
-            result = json.loads(cached_conversations)
+            # Use cached conversations from Redis (may hold more than one turn)
+            result = take_last_conversation_turn(json.loads(cached_conversations))
+            parsed_data["configuration"]["conversation"] = result
             logger.info(f"Retrieved conversations from Redis cache: {redis_key}")
         else:
-            # Fallback to database if not in cache
+            # Fallback to database if not in cache (DB already limited to last 1 turn)
             result = await try_catch(getThread, thread_id, sub_thread_id, org_id, bridge_id)
             if result:
+                result = take_last_conversation_turn(result)
                 parsed_data["configuration"]["conversation"] = result or []
+            else:
+                result = []
     else:
         thread_id = str(uuid.uuid1())
         sub_thread_id = thread_id
@@ -749,7 +777,8 @@ async def prepare_prompt(parsed_data, thread_info, model_config, custom_config):
         id = f"{thread_info['thread_id']}_{thread_info['sub_thread_id']}_{parsed_data.get('version_id') or parsed_data.get('bridge_id')}"
         parsed_data["id"] = id
         if gpt_memory:
-            _memory_id, raw_memory = await get_gpt_memory(
+            # Every request: load GPT memory from cache / Sokt plug, then normalize to pages
+            memory_id, raw_memory = await get_gpt_memory(
                 bridge_id=parsed_data.get("bridge_id"),
                 thread_id=thread_info["thread_id"],
                 sub_thread_id=thread_info["sub_thread_id"],
@@ -757,6 +786,7 @@ async def prepare_prompt(parsed_data, thread_info, model_config, custom_config):
             )
             memory = parse_memory(raw_memory)
             parsed_data["memory"] = memory
+            parsed_data["memory_id"] = memory_id
         configuration["prompt"], missing_vars = Helper.replace_variables_in_prompt(
             configuration.get("prompt") or "", variables
         )

--- a/src/services/utils/gpt_memory.py
+++ b/src/services/utils/gpt_memory.py
@@ -6,6 +6,9 @@ from src.services.cache_service import find_in_cache, store_in_cache
 
 from ..utils.apiservice import fetch
 
+MEMORY_SCHEMA_VERSION = 2
+_META_KEYS = frozenset({"version", "updated_at", "pages"})
+
 
 def _deserialize_cached_value(raw_value):
     """Decode Redis payloads into native python structures."""
@@ -28,14 +31,135 @@ def _is_empty_memory_response(value) -> bool:
     return value.get("success") is True and value.get("message") == "No response"
 
 
-def parse_memory(raw):
-    """Normalize a memory payload to either a dict (new structured form), a string (legacy), or None."""
-    parsed = _deserialize_cached_value(raw)
+def _build_memory_document(pages: dict, updated_at: Any = None) -> dict:
+    doc = {"version": MEMORY_SCHEMA_VERSION, "pages": pages if isinstance(pages, dict) else {}}
+    if updated_at is not None:
+        doc["updated_at"] = updated_at
+    return doc
+
+
+def normalize_memory_to_pages(parsed: Any) -> dict | None:
+    """
+    Normalize any memory payload into:
+      { "version": 2, "pages": { "<key>": <content>, ... }, "updated_at"?: ... }
+    Returns None when there is no usable memory.
+    """
     if parsed is None or _is_empty_memory_response(parsed):
         return None
-    if isinstance(parsed, dict):
-        return parsed
-    return str(parsed)
+
+    if isinstance(parsed, str):
+        text = parsed.strip()
+        if not text:
+            return None
+        return _build_memory_document({"legacy": text})
+
+    if not isinstance(parsed, dict):
+        return _build_memory_document({"legacy": str(parsed)})
+
+    updated_at = parsed.get("updated_at")
+
+    # Already page-shaped: { version?, pages: {...}, updated_at? }
+    pages = parsed.get("pages")
+    if isinstance(pages, dict):
+        if not pages:
+            return None
+        return _build_memory_document(pages, updated_at=updated_at)
+
+    # Top-level content dict (e.g. { "behaviour": ..., "facts": ... }) — treat keys as pages
+    content_pages = {k: v for k, v in parsed.items() if k not in _META_KEYS}
+    if content_pages:
+        return _build_memory_document(content_pages, updated_at=updated_at)
+
+    return None
+
+
+def parse_memory(raw):
+    """
+    Normalize a memory payload to structured JSON pages form, or None.
+
+    Shape:
+      { "version": 2, "pages": { ... }, "updated_at"?: ... }
+
+    Legacy strings become pages.legacy. Dicts with a pages key, or top-level
+    page keys (behaviour/facts/...), are normalized the same way.
+    """
+    parsed = _deserialize_cached_value(raw)
+    return normalize_memory_to_pages(parsed)
+
+
+def get_memory_page_keys(memory: dict | None) -> list[str]:
+    """Return top-level page keys from a normalized memory document."""
+    if not isinstance(memory, dict):
+        return []
+    pages = memory.get("pages")
+    if not isinstance(pages, dict):
+        return []
+    return list(pages.keys())
+
+
+def _outline_page_value(value: Any, *, max_chars: int = 120) -> str:
+    """Short outline of a page value for the agent prompt (not full content)."""
+    if value is None:
+        return "empty"
+    if isinstance(value, dict):
+        if not value:
+            return "empty object"
+        nested = ", ".join(str(k) for k in list(value.keys())[:12])
+        extra = "" if len(value) <= 12 else f", +{len(value) - 12} more"
+        return f"object with fields: {nested}{extra}"
+    if isinstance(value, list):
+        if not value:
+            return "empty list"
+        return f"list with {len(value)} item(s)"
+    if isinstance(value, bool):
+        return f"boolean ({value})"
+    if isinstance(value, (int, float)):
+        return f"number ({value})"
+    text = str(value).strip().replace("\n", " ")
+    if not text:
+        return "empty string"
+    if len(text) > max_chars:
+        return f"text (~{len(text)} chars): {text[:max_chars]}…"
+    return f"text: {text}"
+
+
+def summarize_memory_for_prompt(memory: dict | None) -> list[dict[str, str]]:
+    """
+    Per-page inventory for the system prompt: key + short data outline.
+    Does not dump full page payloads — only enough for the agent to choose keys.
+    """
+    if not isinstance(memory, dict):
+        return []
+    pages = memory.get("pages")
+    if not isinstance(pages, dict):
+        return []
+    return [
+        {"key": str(key), "outline": _outline_page_value(value)}
+        for key, value in pages.items()
+    ]
+
+
+def get_memory_pages(memory: dict | None, keys: list[str] | None = None, include_all: bool = False) -> dict:
+    """
+    Return a slice of memory pages.
+
+    - include_all=True → every page
+    - keys=[...] → only those keys that exist
+    - otherwise → {}
+    """
+    if not isinstance(memory, dict):
+        return {}
+    pages = memory.get("pages")
+    if not isinstance(pages, dict):
+        return {}
+
+    if include_all:
+        return dict(pages)
+
+    if not keys:
+        return {}
+
+    return {key: pages[key] for key in keys if key in pages}
 
 
 async def _fetch_memory_from_cache(memory_id: str):

--- a/src/services/utils/gpt_memory.py
+++ b/src/services/utils/gpt_memory.py
@@ -26,9 +26,11 @@ def _deserialize_cached_value(raw_value):
 
 def _is_empty_memory_response(value) -> bool:
     """Sokt flow returns {'success': True, 'message': 'No response'} when no memory exists for the thread."""
-    if not isinstance(value, dict):
-        return False
-    return value.get("success") is True and value.get("message") == "No response"
+    return (
+        isinstance(value, dict)
+        and value.get("success") is True
+        and value.get("message") == "No response"
+    )
 
 
 def _build_memory_document(pages: dict, updated_at: Any = None) -> dict:
@@ -89,12 +91,10 @@ def parse_memory(raw):
 
 def get_memory_page_keys(memory: dict | None) -> list[str]:
     """Return top-level page keys from a normalized memory document."""
-    if not isinstance(memory, dict):
-        return []
-    pages = memory.get("pages")
-    if not isinstance(pages, dict):
-        return []
-    return list(pages.keys())
+    pages = memory.get("pages") if isinstance(memory, dict) else None
+    if isinstance(pages, dict):
+        return list(pages.keys())
+    return []
 
 
 def _outline_page_value(value: Any, *, max_chars: int = 120) -> str:
@@ -128,15 +128,13 @@ def summarize_memory_for_prompt(memory: dict | None) -> list[dict[str, str]]:
     Per-page inventory for the system prompt: key + short data outline.
     Does not dump full page payloads — only enough for the agent to choose keys.
     """
-    if not isinstance(memory, dict):
-        return []
-    pages = memory.get("pages")
-    if not isinstance(pages, dict):
-        return []
-    return [
-        {"key": str(key), "outline": _outline_page_value(value)}
-        for key, value in pages.items()
-    ]
+    pages = memory.get("pages") if isinstance(memory, dict) else None
+    if isinstance(pages, dict):
+        return [
+            {"key": str(key), "outline": _outline_page_value(value)}
+            for key, value in pages.items()
+        ]
+    return []
 
 
 def get_memory_pages(memory: dict | None, keys: list[str] | None = None, include_all: bool = False) -> dict:
@@ -147,19 +145,13 @@ def get_memory_pages(memory: dict | None, keys: list[str] | None = None, include
     - keys=[...] → only those keys that exist
     - otherwise → {}
     """
-    if not isinstance(memory, dict):
-        return {}
-    pages = memory.get("pages")
-    if not isinstance(pages, dict):
-        return {}
-
-    if include_all:
-        return dict(pages)
-
-    if not keys:
-        return {}
-
-    return {key: pages[key] for key in keys if key in pages}
+    pages = memory.get("pages") if isinstance(memory, dict) else None
+    if isinstance(pages, dict):
+        if include_all:
+            return dict(pages)
+        if keys:
+            return {key: pages[key] for key in keys if key in pages}
+    return {}
 
 
 async def _fetch_memory_from_cache(memory_id: str):

--- a/src/services/utils/gpt_memory_tool.py
+++ b/src/services/utils/gpt_memory_tool.py
@@ -79,51 +79,24 @@ def build_gpt_memory_tool_prompt(memory: dict) -> str:
     )
 
 
-def _strip_previous_memory_prompt(prompt: str) -> str:
-    if not prompt:
-        return ""
-    start = prompt.find(GPT_MEMORY_PROMPT_START)
-    if start == -1:
-        legacy = "Long-term memory is available via the tool"
-        idx = prompt.find(legacy)
-        if idx == -1 or GPT_MEMORY_TOOL_NAME not in prompt[idx:]:
-            return prompt
-        return prompt[:idx].rstrip()
-
-    end = prompt.find(GPT_MEMORY_PROMPT_END)
-    if end == -1:
-        return prompt[:start].rstrip()
-    end += len(GPT_MEMORY_PROMPT_END)
-    return (prompt[:start] + prompt[end:]).strip()
-
-
-def _remove_existing_tool(tools: list, mapping: dict) -> None:
-    tools[:] = [
-        t for t in tools if not (isinstance(t, dict) and t.get("name") == GPT_MEMORY_TOOL_NAME)
-    ]
-    mapping.pop(GPT_MEMORY_TOOL_NAME, None)
-
-
 def attach_gpt_memory_tool(parsed_data: dict, memory: dict | None) -> None:
     """
     After memory is loaded for this request:
-      - pages/keys exist → register get_gpt_memory + refresh prompt inventory
+      - pages/keys exist → register get_gpt_memory + prompt inventory
       - no memory / empty pages → do not add tool or prompt text
     """
     if not parsed_data.get("gpt_memory"):
+        return
+
+    page_keys = get_memory_page_keys(memory)
+    if not page_keys:
         return
 
     configuration = parsed_data.setdefault("configuration", {})
     tools = configuration.setdefault("tools", [])
     mapping = parsed_data.setdefault("tool_id_and_name_mapping", {})
 
-    # Always clear previous registration (keys can change between turns)
-    _remove_existing_tool(tools, mapping)
-    configuration["prompt"] = _strip_previous_memory_prompt(configuration.get("prompt") or "")
-
-    page_keys = get_memory_page_keys(memory)
-    if not page_keys:
-        # No GPT memory for this thread — do not expose the tool or extra prompt text
+    if any(isinstance(t, dict) and t.get("name") == GPT_MEMORY_TOOL_NAME for t in tools):
         return
 
     tools.append(build_get_gpt_memory_tool(page_keys))

--- a/src/services/utils/gpt_memory_tool.py
+++ b/src/services/utils/gpt_memory_tool.py
@@ -1,0 +1,136 @@
+"""
+Register get_gpt_memory at request time from live GPT memory pages.
+
+Flow (every chat request when gpt_memory is enabled):
+  1. prepare_prompt → get_gpt_memory (cache / Sokt plug) → parse_memory
+  2. attach_gpt_memory_tool → if pages/keys exist: add tool + prompt inventory
+     if no memory: add nothing
+  3. LLM may call get_gpt_memory → call_get_gpt_memory reads args, returns pages
+"""
+
+from __future__ import annotations
+
+from src.configs.constant import inbuild_tools
+from src.services.utils.gpt_memory import get_memory_page_keys, summarize_memory_for_prompt
+
+GPT_MEMORY_TOOL_NAME = inbuild_tools["get_gpt_memory"]
+GPT_MEMORY_PROMPT_START = "<!--gpt_memory_tool_prompt_start-->"
+GPT_MEMORY_PROMPT_END = "<!--gpt_memory_tool_prompt_end-->"
+
+
+def build_get_gpt_memory_tool(page_keys: list[str]) -> dict:
+    """Internal function-tool schema (same shape as Gtwy_Web_Search / RAG)."""
+    keys = [str(k) for k in page_keys]
+    keys_list = ", ".join(keys)
+    return {
+        "type": "function",
+        "name": GPT_MEMORY_TOOL_NAME,
+        "description": (
+            "Fetch long-term GPT memory pages for this thread. "
+            f"Available page keys: {keys_list}. "
+            "Request only the keys you need; set all=true only when you need every page."
+        ),
+        "properties": {
+            "keys": {
+                "description": (
+                    "Page keys to return. Choose from: "
+                    + keys_list
+                    + ". Ignored when all is true."
+                ),
+                "type": "array",
+                "items": {"type": "string", "enum": keys},
+                "enum": [],
+                "required": [],
+                "parameter": {},
+            },
+            "all": {
+                "description": "If true, return every memory page. When true, keys is ignored.",
+                "type": "boolean",
+                "enum": [],
+                "required": [],
+                "parameter": {},
+            },
+        },
+        "required": [],
+    }
+
+
+def build_gpt_memory_tool_prompt(memory: dict) -> str:
+    """Prompt block listing live keys + short data outlines (not full payloads)."""
+    inventory = summarize_memory_for_prompt(memory)
+    page_keys = [item["key"] for item in inventory]
+    keys_text = ", ".join(page_keys)
+    lines = "\n".join(f"- `{item['key']}`: {item['outline']}" for item in inventory)
+    example_key = page_keys[0]
+
+    return (
+        f"\n\n{GPT_MEMORY_PROMPT_START}\n"
+        f"Long-term memory is available via the tool `{GPT_MEMORY_TOOL_NAME}`.\n"
+        f"Available page keys: {keys_text}.\n"
+        f"Memory pages currently stored:\n{lines}\n"
+        "Page keys/structure come from stored GPT memory and may change over time.\n"
+        f"- Call `{GPT_MEMORY_TOOL_NAME}` with keys like [\"{example_key}\"] for specific pages.\n"
+        f"- Call with all=true only when you need the full memory.\n"
+        "- Do not invent memory; only use tool results.\n"
+        "- Prefer fetching only the keys you need.\n"
+        "- You only have the latest previous conversation in context; "
+        "use the memory tool for older context.\n"
+        f"{GPT_MEMORY_PROMPT_END}\n"
+    )
+
+
+def _strip_previous_memory_prompt(prompt: str) -> str:
+    if not prompt:
+        return ""
+    start = prompt.find(GPT_MEMORY_PROMPT_START)
+    if start == -1:
+        legacy = "Long-term memory is available via the tool"
+        idx = prompt.find(legacy)
+        if idx == -1 or GPT_MEMORY_TOOL_NAME not in prompt[idx:]:
+            return prompt
+        return prompt[:idx].rstrip()
+
+    end = prompt.find(GPT_MEMORY_PROMPT_END)
+    if end == -1:
+        return prompt[:start].rstrip()
+    end += len(GPT_MEMORY_PROMPT_END)
+    return (prompt[:start] + prompt[end:]).strip()
+
+
+def _remove_existing_tool(tools: list, mapping: dict) -> None:
+    tools[:] = [
+        t for t in tools if not (isinstance(t, dict) and t.get("name") == GPT_MEMORY_TOOL_NAME)
+    ]
+    mapping.pop(GPT_MEMORY_TOOL_NAME, None)
+
+
+def attach_gpt_memory_tool(parsed_data: dict, memory: dict | None) -> None:
+    """
+    After memory is loaded for this request:
+      - pages/keys exist → register get_gpt_memory + refresh prompt inventory
+      - no memory / empty pages → do not add tool or prompt text
+    """
+    if not parsed_data.get("gpt_memory"):
+        return
+
+    configuration = parsed_data.setdefault("configuration", {})
+    tools = configuration.setdefault("tools", [])
+    mapping = parsed_data.setdefault("tool_id_and_name_mapping", {})
+
+    # Always clear previous registration (keys can change between turns)
+    _remove_existing_tool(tools, mapping)
+    configuration["prompt"] = _strip_previous_memory_prompt(configuration.get("prompt") or "")
+
+    page_keys = get_memory_page_keys(memory)
+    if not page_keys:
+        # No GPT memory for this thread — do not expose the tool or extra prompt text
+        return
+
+    tools.append(build_get_gpt_memory_tool(page_keys))
+    mapping[GPT_MEMORY_TOOL_NAME] = {
+        "type": GPT_MEMORY_TOOL_NAME,
+        "name": GPT_MEMORY_TOOL_NAME,
+    }
+    configuration["prompt"] = (configuration.get("prompt") or "") + build_gpt_memory_tool_prompt(
+        memory
+    )


### PR DESCRIPTION
gtwy-ai
src/services/utils/gpt_memory.py

Normalize any legacy/raw payload into { version: 2, pages: {...} }
Helpers: parse_memory, get_memory_page_keys, get_memory_pages, summarize_memory_for_prompt
Empty / “No response” Sokt payloads → None
Load order: Redis first, then Sokt; successful remote fetch cached
src/services/utils/gpt_memory_tool.py (new)

Builds dynamic get_gpt_memory tool schema from live page keys
Builds/refreshes prompt inventory between HTML markers
Strips previous inventory block each request
Early return when gpt_memory off or no page keys
src/services/utils/built_in_tools/gpt_memory.py (new)

Executes tool args:
all=true → all pages
keys=[...] → only existing keys
neither → error + available_keys (returned to the model as tool content)
src/services/utils/common_utils.py

In prepare_prompt, load + parse memory when enabled
Store parsed_data["memory"] / memory_id
Keep last conversation turn helpers aligned with new history policy
src/services/commonServices/common.py

After prepare_prompt, call attach_gpt_memory_tool
Keep custom_config["tools"] in sync
src/services/commonServices/baseService/utils.py

Route inbuild tool type get_gpt_memory → call_get_gpt_memory
Existing 3-turn writer scheduling unchanged in spirit (GPT_MEMORY_TURNS_PER_CYCLE)
src/services/commonServices/createConversations.py

Remove always-injecting full GPT memory into conversation history
src/db_services/conversationDbService.py

Limit fetched conversation logs to last 1 turn
src/configs/constant.py

Register inbuild tool: get_gpt_memory